### PR TITLE
Classes: Mage: Rewrite spells to Wurst.

### DIFF
--- a/jass/trolls/mage/Dark Gate.j
+++ b/jass/trolls/mage/Dark Gate.j
@@ -219,7 +219,7 @@ endfunction
 function InitTrig_Dark_Gate takes nothing returns nothing
     set gg_trg_Dark_Gate = CreateTrigger(  )
     call TriggerAddCondition( gg_trg_Dark_Gate, Condition( function Trig_Dark_Gate_Conditions ) )
-    call TriggerAddAction( gg_trg_Dark_Gate, function Trig_Dark_Gate_Actions )
+    //call TriggerAddAction( gg_trg_Dark_Gate, function Trig_Dark_Gate_Actions )
 endfunction
 
 //===========================================================================

--- a/jass/trolls/mage/Defender Orb.j
+++ b/jass/trolls/mage/Defender Orb.j
@@ -32,7 +32,7 @@ function InitTrig_Defender_Orb takes nothing returns nothing
     set gg_trg_Defender_Orb = CreateTrigger(  )
   //  call TriggerRegisterAnyUnitEventBJ( gg_trg_Defender_Orb, EVENT_PLAYER_UNIT_SPELL_CAST )
     call TriggerAddCondition( gg_trg_Defender_Orb, Condition( function Trig_Orb_Conditions ) )
-    call TriggerAddAction( gg_trg_Defender_Orb, function Trig_Orb_Actions )
+    //call TriggerAddAction( gg_trg_Defender_Orb, function Trig_Orb_Actions )
 endfunction
 
 //===========================================================================

--- a/jass/trolls/mage/Depress Mana Drain.j
+++ b/jass/trolls/mage/Depress Mana Drain.j
@@ -35,7 +35,7 @@ function InitTrig_depress_mana_drain takes nothing returns nothing
     set gg_trg_depress_mana_drain = CreateTrigger(  )
   //  call TriggerRegisterAnyUnitEventBJ( gg_trg_depress_mana_drain, EVENT_PLAYER_UNIT_SPELL_CAST )
     call TriggerAddCondition( gg_trg_depress_mana_drain, Condition( function Trig_depress_mana_drain_Conditions ) )
-    call TriggerAddAction( gg_trg_depress_mana_drain, function Trig_depress_mana_drain_Actions )
+    //call TriggerAddAction( gg_trg_depress_mana_drain, function Trig_depress_mana_drain_Actions )
 endfunction
 
 //===========================================================================

--- a/jass/trolls/mage/Depression Orb.j
+++ b/jass/trolls/mage/Depression Orb.j
@@ -32,7 +32,7 @@ function InitTrig_Depression_Orb takes nothing returns nothing
     set gg_trg_Depression_Orb = CreateTrigger(  )
  //   call TriggerRegisterAnyUnitEventBJ( gg_trg_Depression_Orb, EVENT_PLAYER_UNIT_SPELL_CAST )
     call TriggerAddCondition( gg_trg_Depression_Orb, Condition( function Trig_DOrb_Conditions ) )
-    call TriggerAddAction( gg_trg_Depression_Orb, function Trig_DOrb_Actions )
+    //call TriggerAddAction( gg_trg_Depression_Orb, function Trig_DOrb_Actions )
 endfunction
 
 //===========================================================================

--- a/jass/trolls/mage/Dream Eater.j
+++ b/jass/trolls/mage/Dream Eater.j
@@ -35,7 +35,7 @@ endfunction
 function InitTrig_Dream_Eater takes nothing returns nothing
     set gg_trg_Dream_Eater = CreateTrigger(  )
     call TriggerAddCondition( gg_trg_Dream_Eater, Condition( function Trig_Dream_Eater_Conditions ) )
-    call TriggerAddAction( gg_trg_Dream_Eater, function Trig_Dream_Eater_Actions )
+    //call TriggerAddAction( gg_trg_Dream_Eater, function Trig_Dream_Eater_Actions )
 endfunction
 
 //===========================================================================

--- a/jass/trolls/mage/Electromagnet.j
+++ b/jass/trolls/mage/Electromagnet.j
@@ -96,7 +96,7 @@ function InitTrig_electromagnet takes nothing returns nothing
     set gg_trg_electromagnet = CreateTrigger(  )
   //  call TriggerRegisterAnyUnitEventBJ( gg_trg_electromagnet, EVENT_PLAYER_UNIT_SPELL_CAST )
     call TriggerAddCondition( gg_trg_electromagnet, Condition( function Trig_electromagnet_Conditions ) )
-    call TriggerAddAction( gg_trg_electromagnet, function Trig_electromagnet_Actions )
+    //call TriggerAddAction( gg_trg_electromagnet, function Trig_electromagnet_Actions )
 endfunction
 
 //===========================================================================

--- a/jass/trolls/mage/Eruption.j
+++ b/jass/trolls/mage/Eruption.j
@@ -33,7 +33,7 @@ endfunction
 function InitTrig_Eruption takes nothing returns nothing
     set gg_trg_Eruption = CreateTrigger(  )
     call TriggerAddCondition( gg_trg_Eruption, Condition( function Trig_Eruption_Conditions ) )
-    call TriggerAddAction( gg_trg_Eruption, function Trig_Eruption_Actions )
+    //call TriggerAddAction( gg_trg_Eruption, function Trig_Eruption_Actions )
 endfunction
 
 //===========================================================================

--- a/jass/trolls/mage/Hypnosis.j
+++ b/jass/trolls/mage/Hypnosis.j
@@ -17,7 +17,7 @@ function InitTrig_hypnosis takes nothing returns nothing
     set gg_trg_hypnosis = CreateTrigger(  )
     call TriggerRegisterAnyUnitEventBJ( gg_trg_hypnosis, EVENT_PLAYER_UNIT_SPELL_EFFECT )
     call TriggerAddCondition( gg_trg_hypnosis, Condition( function Trig_sleeping_2_Conditions ) )
-    call TriggerAddAction( gg_trg_hypnosis, function Trig_sleeping_2_Actions )
+    //call TriggerAddAction( gg_trg_hypnosis, function Trig_sleeping_2_Actions )
 endfunction
 
 //===========================================================================

--- a/jass/trolls/mage/Invoke Runes.j
+++ b/jass/trolls/mage/Invoke Runes.j
@@ -110,7 +110,7 @@ endfunction
 function InitTrig_Invoke_Runes takes nothing returns nothing
     set gg_trg_Invoke_Runes = CreateTrigger(  )
     call TriggerAddCondition( gg_trg_Invoke_Runes, Condition( function Trig_Invoke_Runes_Conditions ) )
-    call TriggerAddAction( gg_trg_Invoke_Runes, function Trig_Invoke_Runes_Actions )
+    //call TriggerAddAction( gg_trg_Invoke_Runes, function Trig_Invoke_Runes_Actions )
 endfunction
 
 //===========================================================================

--- a/jass/trolls/mage/Jeoulusy.j
+++ b/jass/trolls/mage/Jeoulusy.j
@@ -51,7 +51,7 @@ function InitTrig_jeoulusy takes nothing returns nothing
     set gg_trg_jeoulusy = CreateTrigger(  )
  //   call TriggerRegisterAnyUnitEventBJ( gg_trg_jeoulusy, EVENT_PLAYER_UNIT_SPELL_CAST )
     call TriggerAddCondition( gg_trg_jeoulusy, Condition( function Trig_jeoulusy_Conditions ) )
-    call TriggerAddAction( gg_trg_jeoulusy, function jelousyFunc )
+    //call TriggerAddAction( gg_trg_jeoulusy, function jelousyFunc )
 endfunction
 
 //===========================================================================

--- a/jass/trolls/mage/Metronome.j
+++ b/jass/trolls/mage/Metronome.j
@@ -59,7 +59,7 @@ function InitTrig_metronome takes nothing returns nothing
     set gg_trg_metronome = CreateTrigger(  )
   //  call TriggerRegisterAnyUnitEventBJ( gg_trg_metronome, EVENT_PLAYER_UNIT_SPELL_CAST )
     call TriggerAddCondition( gg_trg_metronome, Condition( function Trig_metronome_Conditions ) )
-    call TriggerAddAction( gg_trg_metronome, function Trig_metronome_Actions )
+    //call TriggerAddAction( gg_trg_metronome, function Trig_metronome_Actions )
 endfunction
 
 //===========================================================================

--- a/jass/trolls/mage/Reduce Food Reduction.j
+++ b/jass/trolls/mage/Reduce Food Reduction.j
@@ -40,7 +40,7 @@ endfunction
 function InitTrig_Reduce_Food_reduction takes nothing returns nothing
     set gg_trg_Reduce_Food_reduction = CreateTrigger(  )
     call TriggerAddCondition( gg_trg_Reduce_Food_reduction, Condition( function Trig_Reduce_Food_reduction_Conditions ) )
-    call TriggerAddAction( gg_trg_Reduce_Food_reduction, function Trig_Reduce_Food_reduction_Actions )
+    //call TriggerAddAction( gg_trg_Reduce_Food_reduction, function Trig_Reduce_Food_reduction_Actions )
 endfunction
 
 //===========================================================================

--- a/jass/trolls/mage/Rune Release.j
+++ b/jass/trolls/mage/Rune Release.j
@@ -248,7 +248,7 @@ library RuneRelease initializer onInit requires DUMMYLIB, PublicLibrary
   function onInit takes nothing returns nothing
       set gg_trg_Rune_Release = CreateTrigger(  )
       call TriggerAddCondition( gg_trg_Rune_Release, Condition( function Trig_Rune_Release_Conditions ) )
-      call TriggerAddAction( gg_trg_Rune_Release, function Trig_Rune_Release_Actions )
+      //call TriggerAddAction( gg_trg_Rune_Release, function Trig_Rune_Release_Actions )
   endfunction
 
 endlibrary

--- a/jass/trolls/mage/Seizures.j
+++ b/jass/trolls/mage/Seizures.j
@@ -55,7 +55,7 @@ function InitTrig_seizures takes nothing returns nothing
     set gg_trg_seizures = CreateTrigger(  )
   //  call TriggerRegisterAnyUnitEventBJ( gg_trg_seizures, EVENT_PLAYER_UNIT_SPELL_CAST )
     call TriggerAddCondition( gg_trg_seizures, Condition( function Trig_seizures_Conditions ) )
-    call TriggerAddAction( gg_trg_seizures, function seizureFunc )
+    //call TriggerAddAction( gg_trg_seizures, function seizureFunc )
 endfunction
 
 //===========================================================================

--- a/jass/trolls/mage/Splitting Flame.j
+++ b/jass/trolls/mage/Splitting Flame.j
@@ -42,7 +42,7 @@ endfunction
 function InitTrig_Splitting_Flame takes nothing returns nothing
     set gg_trg_Splitting_Flame = CreateTrigger(  )
     call TriggerAddCondition( gg_trg_Splitting_Flame, Condition( function Trig_Splitting_Flame_Conditions ) )
-    call TriggerAddAction( gg_trg_Splitting_Flame, function Trig_Splitting_Flame_Actions )
+    //call TriggerAddAction( gg_trg_Splitting_Flame, function Trig_Splitting_Flame_Actions )
 endfunction
 
 //===========================================================================

--- a/jass/trolls/mage/Storm Earth Fire.j
+++ b/jass/trolls/mage/Storm Earth Fire.j
@@ -41,7 +41,7 @@ function InitTrig_Storm_Earth_Fire takes nothing returns nothing
     set gg_trg_Storm_Earth_Fire = CreateTrigger(  )
   //  call TriggerRegisterAnyUnitEventBJ( gg_trg_Storm_Earth_Fire, EVENT_PLAYER_UNIT_SPELL_CAST )
     call TriggerAddCondition( gg_trg_Storm_Earth_Fire, Condition( function Trig_Storm_Earth_Fire_Conditions ) )
-    call TriggerAddAction( gg_trg_Storm_Earth_Fire, function Trig_Storm_Earth_Fire_Actions )
+    //call TriggerAddAction( gg_trg_Storm_Earth_Fire, function Trig_Storm_Earth_Fire_Actions )
 endfunction
 
 //===========================================================================

--- a/jass/trolls/mage/Stup Aura Remove.j
+++ b/jass/trolls/mage/Stup Aura Remove.j
@@ -21,7 +21,7 @@ function InitTrig_Stup_Aura_Remove takes nothing returns nothing
     set gg_trg_Stup_Aura_Remove = CreateTrigger(  )
     call TriggerRegisterAnyUnitEventBJ( gg_trg_Stup_Aura_Remove, EVENT_PLAYER_UNIT_SPELL_FINISH )
     call TriggerAddCondition( gg_trg_Stup_Aura_Remove, Condition( function Trig_Stup_Aura_Remove_Conditions ) )
-    call TriggerAddAction( gg_trg_Stup_Aura_Remove, function Trig_Stup_Aura_Remove_Actions )
+    //call TriggerAddAction( gg_trg_Stup_Aura_Remove, function Trig_Stup_Aura_Remove_Actions )
 endfunction
 
 //===========================================================================

--- a/jass/trolls/mage/Stup Aura.j
+++ b/jass/trolls/mage/Stup Aura.j
@@ -19,7 +19,7 @@ function InitTrig_Stup_Aura takes nothing returns nothing
     set gg_trg_Stup_Aura = CreateTrigger(  )
     call TriggerRegisterAnyUnitEventBJ( gg_trg_Stup_Aura, EVENT_PLAYER_UNIT_SPELL_CHANNEL )
     call TriggerAddCondition( gg_trg_Stup_Aura, Condition( function Trig_Stup_Aura_Conditions ) )
-    call TriggerAddAction( gg_trg_Stup_Aura, function Trig_Stup_Aura_Actions )
+    //call TriggerAddAction( gg_trg_Stup_Aura, function Trig_Stup_Aura_Actions )
 endfunction
 
 //===========================================================================

--- a/wurst/classes/mage/Depress.wurst
+++ b/wurst/classes/mage/Depress.wurst
@@ -1,0 +1,15 @@
+package Depress
+import RegisterEvents
+import ClosureTimers
+
+@configurable constant int ABILITY_ID = 'A025'
+
+function onCast()
+    var target = GetSpellTargetUnit()
+    if target.getMana() < 40
+        return
+    target.subMana(10)
+    doPeriodicallyCounted(2.00, 4, (cb) -> target.subMana(5))
+
+init
+    registerSpellEffectEvent(ABILITY_ID, () -> onCast())

--- a/wurst/classes/mage/Metronome.wurst
+++ b/wurst/classes/mage/Metronome.wurst
@@ -1,0 +1,55 @@
+package Metronome
+import RegisterEvents
+import Table
+import Orders
+import InstantDummyCaster
+import ClosureTimers
+import EventHelper
+
+@configurable constant int ABILITY_ID = 'A01Z'
+
+constant table = new Table()
+
+function initSpellTable()
+    table.saveInt(0, 'A028')
+    table.saveInt(1, 'A028')
+    table.saveInt(2, 'A038')
+    table.saveInt(3, 'A038')
+    table.saveInt(4, 'A02A')
+    table.saveInt(5, 'A02A')
+    table.saveInt(6, 'A01K')
+    table.saveInt(7, 'A065')
+    table.saveInt(8, 'A02V')
+    // Unlucky, lonely spell
+    table.saveInt(9, 'A02B')
+
+    table.saveInt('A028', Orders.impale)
+    table.saveInt('A038', Orders.carrionswarm)
+    table.saveInt('A02A', Orders.frostnova)
+    table.saveInt('A01K', Orders.shadowstrike)
+    table.saveInt('A065', Orders.manaburn)
+    table.saveInt('A02V', Orders.creepthunderbolt)
+    table.saveInt('A02B', Orders.frostnova)
+
+function onCast()
+    var target = GetSpellTargetUnit()
+    var targetPos = getSpellTargetPos()
+    var pos = targetPos.polarOffset(GetRandomReal(0, 360).fromDeg(), GetRandomReal(0, 100))
+    var owner = GetSpellAbilityUnit().getOwner()
+    var abilityId = table.loadInt(9)
+
+    if GetRandomInt(0, 2) == 0
+        InstantDummyCaster.castTarget(owner, abilityId, 1, table.loadInt(abilityId), target, pos)
+        return
+
+    abilityId = table.loadInt(GetRandomInt(0, 8))
+    InstantDummyCaster.castTarget(owner, abilityId, 1, table.loadInt(abilityId), target, pos)
+
+    doPeriodicallyCounted(1.00, GetRandomInt(3, 5)) cb ->
+        abilityId = table.loadInt(GetRandomInt(0, 8))
+        pos = targetPos.polarOffset(GetRandomReal(0, 360).fromDeg(), GetRandomReal(0, 400))
+        InstantDummyCaster.castTarget(owner, abilityId, 1, table.loadInt(abilityId), target, pos)
+
+init
+    initSpellTable()
+    registerSpellEffectEvent(ABILITY_ID, () -> onCast())

--- a/wurst/classes/mage/ReduceFood.wurst
+++ b/wurst/classes/mage/ReduceFood.wurst
@@ -1,0 +1,18 @@
+package ReduceFood
+import RegisterEvents
+
+@configurable constant int ABILITY_ID = 'A029'
+
+function onCast()
+    var target = GetSpellTargetUnit()
+    var size = target.inventorySize()
+
+    for slot = 0 to size - 1
+        var itm = target.itemInSlot(slot)
+        var charges = itm.getCharges()
+        if itm.getTypeId() == ITEM_COOKED_MEAT and charges > 2
+            itm.setCharges(charges - 1)
+            break
+
+init
+    registerSpellEffectEvent(ABILITY_ID, () -> onCast())

--- a/wurst/classes/mage/dementia/ActivateRunes.wurst
+++ b/wurst/classes/mage/dementia/ActivateRunes.wurst
@@ -1,0 +1,139 @@
+package ActivateRunes
+import RuneRing
+import DarkGate
+import RegisterEvents
+import Orders
+import Table
+import LinkedList
+import ClosureTimers
+import InstantDummyCaster
+
+@configurable constant int ABILITY_ID = 'A07B'
+@configurable constant int REQ_ABILITY_ID = 'A07D'
+@configurable constant real PORTAL_OFFSET = 150
+@configurable constant real RADIUS = 300
+
+constant OFFSET = PORTAL_OFFSET * PORTAL_OFFSET // avoid square root
+constant table = new Table()
+
+function initSpellTable()
+    table.saveInt('A07C', Orders.creepthunderbolt)
+    table.saveInt('A02A', Orders.frostnova)
+    table.saveInt('A01Y', Orders.cripple)
+    table.saveInt('A064', Orders.soulburn)
+    table.saveInt('A03E', Orders.drunkenhaze)
+
+tuple summonInfo(int unitId, string name, int orderId, real cooldown, LinkedList<int> runeOrder)
+constant NULL_SUMMON = summonInfo(0, null, 0, -1, null)
+
+summonInfo kalezkaNelka = summonInfo(UNIT_LOCUST_FIRE_LORD, "|c00ff0000Kalezka Nelka|r", Orders.acidbomb, 1, new LinkedList<int>())
+summonInfo leznelLezlezka = summonInfo(UNIT_LOCUST_WATER_LORD, "|c00005a95Leznel Lezlezka|r", Orders.thunderbolt, 1, new LinkedList<int>())
+summonInfo nelnelkaNellez = summonInfo(UNIT_LOCUST_GHOST, "|c0075f041Nelnelka Nellez|r", Orders.soulburn, 1.5, new LinkedList<int>())
+
+function initSummonCombinations()
+    kalezkaNelka.runeOrder.add(UNIT_LOCUST_KA, UNIT_LOCUST_LEZ, UNIT_LOCUST_KA, UNIT_LOCUST_NEL, UNIT_LOCUST_KA)
+    leznelLezlezka.runeOrder.add(UNIT_LOCUST_LEZ, UNIT_LOCUST_NEL, UNIT_LOCUST_LEZ, UNIT_LOCUST_LEZ, UNIT_LOCUST_KA)
+    nelnelkaNellez.runeOrder.add(UNIT_LOCUST_NEL, UNIT_LOCUST_NEL, UNIT_LOCUST_KA, UNIT_LOCUST_NEL, UNIT_LOCUST_LEZ)
+
+function LinkedList<int>.equals(LinkedList<int> other) returns boolean
+    if other == null or this.size() != other.size()
+        return false
+    var iter = other.staticItr()
+    for elem in this
+        if elem != iter.next()
+            return false
+    return true
+
+function getSummonInfo(LinkedList<int> runeOrder) returns summonInfo
+    summonInfo result = NULL_SUMMON
+    if runeOrder.equals(kalezkaNelka.runeOrder)
+        result = kalezkaNelka
+    else if runeOrder.equals(leznelLezlezka.runeOrder)
+        result = leznelLezlezka
+    else if runeOrder.equals(nelnelkaNellez.runeOrder)
+        result = nelnelkaNellez
+    return result
+
+function unit.getRuneSpell() returns int
+    var result = 'A07C' // defaults to UNIT_LOCUST_KA
+    var unitId = this.getTypeId()
+
+    if unitId == UNIT_LOCUST_LEZ
+        result = (GetRandomInt(0, 1) == 1) ? 'A02A' : 'A01Y'
+    else if unitId == UNIT_LOCUST_NEL
+        result = (GetRandomInt(0, 1) == 1) ? 'A064' : 'A03E'
+    return result
+
+player filterPlayer = null
+function filterAnyTarget(unit u) returns boolean
+    return u.isAlive() and not u.isType(UNIT_TYPE_STRUCTURE)
+
+function filterEnemyTarget(unit u) returns boolean
+    return filterAnyTarget(u) and u.getOwner().isEnemyOf(filterPlayer)
+
+function getNearbyActiveGate(unit u) returns DarkGate
+    DarkGate result = null
+    var gates = getActiveDarkGates()
+    var pos = u.getPos()
+
+    for gate in gates
+        if gate.caster == u and (result == null or gate.remaining > result.remaining)
+            var dvec = pos - gate.pos
+            if dvec.dot(dvec) <= OFFSET
+                result = gate
+    return result
+
+function onCast()
+    var caster = GetSpellAbilityUnit()
+    var runes = caster.getRuneList()
+    if runes == null or runes.isEmpty()
+        return
+
+    var gate = getNearbyActiveGate(caster)
+    var summonData = NULL_SUMMON
+    if gate != null and caster.hasAbility(REQ_ABILITY_ID)
+        if runes != null
+            var runeOrder = new LinkedList<int>()
+            runes.forEach(e -> runeOrder.push(e.getTypeId()))
+            summonData = getSummonInfo(runeOrder)
+
+    var owner = caster.getOwner()
+    if summonData != NULL_SUMMON
+        var pos = gate.pos
+        var summon = createUnit(owner, summonData.unitId, pos, (270).fromDeg())
+        gate.summons.push(summon)
+        printTimedToPlayer(GENERAL_COLOR + "You have summoned " + summonData.name + GENERAL_COLOR + "!|r", 7, owner)
+
+        doPeriodically(summonData.cooldown) cb ->
+            if summon.isAlive()
+                filterPlayer = owner
+                ENUM_GROUP.enumUnitsInRange(pos, RADIUS, Filter(() -> filterEnemyTarget(GetFilterUnit())))
+                var target = ENUM_GROUP.getRandomUnit()
+
+                if target == null
+                    ENUM_GROUP.enumUnitsInRange(pos, RADIUS, Filter(() -> filterAnyTarget(GetFilterUnit())))
+                    target = ENUM_GROUP.getRandomUnit()
+                if target != null
+                    summon.issueTargetOrderById(summonData.orderId, target)
+            else
+                destroy cb
+    else
+        var pos = caster.getPos()
+        for rune in runes
+            filterPlayer = owner
+            ENUM_GROUP.enumUnitsInRange(pos, RADIUS, Filter(() -> filterEnemyTarget(GetFilterUnit())))
+            var target = ENUM_GROUP.getRandomUnit()
+
+            if target != null
+                rune.issuePointOrderById(Orders.move, target.getPos())
+                var abilityId = rune.getRuneSpell()
+                InstantDummyCaster.castTarget(owner, abilityId, 1, table.loadInt(abilityId), target, target.getPos())
+                rune.setTimedLife(1)
+            else
+                rune.kill()
+        runes.clear()
+
+init
+    initSpellTable()
+    initSummonCombinations()
+    registerSpellEffectEvent(ABILITY_ID, () -> onCast())

--- a/wurst/classes/mage/dementia/DarkGate.wurst
+++ b/wurst/classes/mage/dementia/DarkGate.wurst
@@ -1,0 +1,150 @@
+package DarkGate
+import RegisterEvents
+import LinkedList
+import Table
+import ClosureTimers
+import InstantDummyCaster
+import Orders
+
+@configurable constant int ABILITY_ID = 'A076'
+@configurable constant int DUMMY_ID = UNIT_LOCUST_DARK_NODE
+@configurable constant real INTERVAL = 0.05
+@configurable constant real TURN_SPEED = 80
+@configurable constant real RUN_SPEED = 100
+@configurable constant real DISTANCE = 100
+@configurable constant int MAX_DUMMY_COUNT = 6
+@configurable constant real GROW_DURATION = 10
+@configurable constant real MIN_GROW_DURATION = 1.5
+@configurable constant real AURA_DURATION = 40
+@configurable constant EFFECT_PATH = "Abilities\\Spells\\Demon\\DarkPortal\\DarkPortalTarget.mdl"
+
+constant INTERVAL_RUN_SPEED = INTERVAL * RUN_SPEED
+constant INTERVAL_TURN_SPEED = (INTERVAL * TURN_SPEED).fromDeg()
+constant INTERVAL_DURATION_GROWTH = INTERVAL * AURA_DURATION
+
+constant ongoing = new LinkedList<DarkGate>()
+
+public function getActiveDarkGates() returns LinkedList<DarkGate>
+    return ongoing
+
+constant instances = new Table()
+constant table = new Table()
+
+function initSpellTable()
+    table.saveInt(0, 'A038')
+    table.saveInt(1, 'A038')
+    table.saveInt(2, 'A01K')
+    table.saveInt(3, 'A01K')
+    table.saveInt(4, 'A02A')
+    table.saveInt(5, 'A02A')
+    table.saveInt(6, 'A028')
+    table.saveInt(7, 'A065')
+    table.saveInt(8, 'A02V')
+    table.saveInt(9, 'ACfl')
+    table.saveInt(10, 'ACtb')
+    table.saveInt(11, 'A020')
+    table.saveInt(12, 'A01X')
+
+    table.saveInt('A038', Orders.carrionswarm)
+    table.saveInt('A01K', Orders.shadowstrike)
+    table.saveInt('A02A', Orders.frostnova)
+    table.saveInt('A028', Orders.impale)
+    table.saveInt('A065', Orders.manaburn)
+    table.saveInt('A02V', Orders.creepthunderbolt)
+    table.saveInt('ACfl', Orders.forkedlightning)
+    table.saveInt('ACtb', Orders.creepthunderbolt)
+    table.saveInt('A020', Orders.frostnova)
+    table.saveInt('A01X', Orders.chainlightning)
+
+public class DarkGate
+    constant orbs = new LinkedList<unit>()
+    constant summons = new LinkedList<unit>()
+    unit caster
+    vec2 pos
+    var remaining = 0.00
+    var channeling = true
+    var distance = DISTANCE
+
+    construct(unit caster)
+        var owner = caster.getOwner()
+        var pos = caster.getPos()
+        var inc = 360 / MAX_DUMMY_COUNT
+        this.caster = caster
+        this.pos = pos
+
+        for i = 0 to MAX_DUMMY_COUNT - 1
+            var angle = (i * inc).fromDeg()
+            var dpos = pos.polarOffset(angle, distance)
+            orbs.push(createUnit(owner, DUMMY_ID, dpos, angle))
+        instances.saveInt(caster.getHandleId(), this castTo int)
+
+    ondestroy
+        var duration = (remaining <= MIN_GROW_DURATION) ? 0.2 : 1.8
+        for orb in orbs
+            duration += 0.2
+            orb.setTimedLife(duration)
+        summons.forEach(e -> e.setTimedLife(duration))
+
+        var last = instances.loadInt(caster.getHandleId()) castTo thistype
+        if last == this
+            instances.removeInt(caster.getHandleId())
+        ongoing.remove(this)
+        destroy orbs
+        destroy summons
+
+player filterPlayer = null
+function filterTarget(unit u) returns boolean
+    return u.getOwner().isEnemyOf(filterPlayer) and u.isAlive() and not u.isType(UNIT_TYPE_STRUCTURE)
+
+function orbCastSpell(DarkGate gate, int index)
+    filterPlayer = gate.caster.getOwner()
+    ENUM_GROUP.enumUnitsInRange(gate.pos, gate.distance, Filter(() -> filterTarget(GetFilterUnit())))
+    var target = ENUM_GROUP.getRandomUnit()
+
+    if target != null
+        var orb = gate.orbs.get(index)
+        var abilityId = table.loadInt(GetRandomInt(0, 12))
+        var efx = orb.addEffect(EFFECT_PATH, "origin")
+        InstantDummyCaster.castTarget(filterPlayer, abilityId, 1, table.loadInt(abilityId), target, orb.getPos())
+        doAfter(1.5, () -> efx.destr())
+
+function onCast()
+    var caster = GetSpellAbilityUnit()
+    var gate = new DarkGate(caster)
+
+    doPeriodicallyTimed(INTERVAL, GROW_DURATION) cb ->
+        gate.remaining += INTERVAL_DURATION_GROWTH
+        if not caster.isAlive()
+            cb.stop()
+            destroy gate
+        else if cb.isLast() or not gate.channeling
+            cb.stop()
+            if gate.remaining <= (MIN_GROW_DURATION / GROW_DURATION) * AURA_DURATION
+                destroy gate
+            else
+                var scale = gate.remaining / AURA_DURATION
+                var interval = 2.5 - scale
+                ongoing.push(gate)
+                doPeriodicallyTimed(interval, gate.remaining) cb2 ->
+                    gate.remaining -= interval
+                    orbCastSpell(gate, cb2.getCount() mod MAX_DUMMY_COUNT)
+                    if cb2.isLast()
+                        destroy gate
+        else
+            gate.distance += INTERVAL_RUN_SPEED
+            for orb in gate.orbs
+                var angle = orb.getFacingAngle() + INTERVAL_TURN_SPEED
+                var resultPos = gate.pos.polarOffset(angle, gate.distance)
+                orb.setFacing(angle)
+                orb.setXY(resultPos)
+
+function onEndcast()
+    if GetSpellAbilityId() == ABILITY_ID
+        var caster = GetSpellAbilityUnit()
+        var gate = instances.loadInt(caster.getHandleId()) castTo DarkGate
+        gate.channeling = false
+
+init
+    initSpellTable()
+    registerSpellEffectEvent(ABILITY_ID, () -> onCast())
+    registerPlayerUnitEvent(EVENT_PLAYER_UNIT_SPELL_ENDCAST, () -> onEndcast())

--- a/wurst/classes/mage/dementia/RuneRing.wurst
+++ b/wurst/classes/mage/dementia/RuneRing.wurst
@@ -1,0 +1,98 @@
+package RuneRing
+import RegisterEvents
+import LinkedList
+import Table
+
+@configurable constant int NEL_ABILITY_ID = 'A06S'
+@configurable constant int KA_ABILITY_ID = 'A079'
+@configurable constant int LEZ_ABILITY_ID = 'A07A'
+@configurable constant real INTERVAL = 0.05
+@configurable constant real SPEED = 50
+@configurable constant real DISTANCE = 300
+@configurable constant int MAX_DUMMY_COUNT = 5
+
+constant INTERVAL_SPEED = (INTERVAL * SPEED).fromDeg()
+
+constant looper = CreateTimer()
+constant ongoing = new LinkedList<RuneRing>()
+constant instances = new Table()
+
+public function unit.getRuneList() returns LinkedList<unit>
+    LinkedList<unit> result = null
+    var index = this.getHandleId()
+    if instances.hasInt(index)
+        result = (instances.loadInt(index) castTo RuneRing).runes
+    return result
+
+function int.getRuneType() returns int
+    var result = UNIT_LOCUST_LEZ
+
+    if this == NEL_ABILITY_ID
+        result = UNIT_LOCUST_NEL
+    else if this == KA_ABILITY_ID
+        result = UNIT_LOCUST_KA
+    return result
+
+class RuneRing
+    constant runes = new LinkedList<unit>()
+    unit caster
+
+    construct(unit caster)
+        this.caster = caster
+        ongoing.push(this)
+        instances.saveInt(caster.getHandleId(), this castTo int)
+
+    ondestroy
+        runes.forEach(e -> e.kill())
+        destroy runes
+        ongoing.remove(this)
+        if ongoing.isEmpty()
+            looper.pause()
+        instances.removeInt(caster.getHandleId())
+
+    /** Appends new rune to the end of the ring. If full, dequeues head rune before insertion. */
+    function summonRune(int runeType)
+        var angle = angle(0)
+        var count = runes.size()
+
+        if count == MAX_DUMMY_COUNT
+            var rune = runes.dequeue()
+            angle = rune.getFacingAngle()
+            rune.remove()
+        else if count > 0
+            var rune = runes.peek()
+            angle = rune.getFacingAngle() - (360 / MAX_DUMMY_COUNT).fromDeg()
+        var pos = caster.getPos().polarOffset(angle, DISTANCE)
+        var u = createUnit(caster.getOwner(), runeType, pos, angle)
+        runes.push(u)
+
+function onCallback()
+    var iter = ongoing.iterator()
+    for ring from iter
+        if not ring.caster.isAlive() or ring.runes.isEmpty()
+            iter.remove()
+            destroy ring
+        else
+            var pos = ring.caster.getPos()
+            for rune in ring.runes
+                var angle = rune.getFacingAngle() + INTERVAL_SPEED
+                var rpos = pos.polarOffset(angle, DISTANCE)
+                rune.setFacing(angle)
+                rune.setXY(rpos)
+    iter.close()
+
+function onCast()
+    var caster = GetSpellAbilityUnit()
+    RuneRing ring
+    if instances.hasInt(caster.getHandleId())
+        ring = instances.loadInt(caster.getHandleId()) castTo RuneRing
+    else
+        if ongoing.isEmpty()
+            looper.startPeriodic(INTERVAL, () -> onCallback())
+        ring = new RuneRing(caster)
+    ring.summonRune(GetSpellAbilityId().getRuneType())
+
+init
+    registerSpellEffectEvent(NEL_ABILITY_ID, () -> onCast())
+    registerSpellEffectEvent(KA_ABILITY_ID, () -> onCast())
+    registerSpellEffectEvent(LEZ_ABILITY_ID, () -> onCast())

--- a/wurst/classes/mage/elementalist/DefenderOrb.wurst
+++ b/wurst/classes/mage/elementalist/DefenderOrb.wurst
@@ -1,0 +1,39 @@
+package DefenderOrb
+import RegisterEvents
+import Orders
+import InstantDummyCaster
+import ClosureTimers
+import ClosureForGroups
+import EventHelper
+
+@configurable constant int ABILITY_ID = 'A04P'
+@configurable constant int DUMMY_ABILITY_ID = 'A04O'
+@configurable constant int DUMMY_ID = UNIT_LOCUST_ALT
+@configurable constant int BUFF_ID = 'BPSE'
+@configurable constant real INTERVAL = 0.05
+@configurable constant real DURATION = 10
+@configurable constant real SPEED = 400
+@configurable constant real DISTANCE = 300
+@configurable constant real RADIUS = 200
+
+constant INTERVAL_SPEED = INTERVAL * SPEED
+
+function onCast()
+    var owner = GetSpellAbilityUnit().getOwner()
+    var pos = getSpellTargetPos()
+    var angle = angle(0)
+    var dummy = createUnit(owner, DUMMY_ID, pos.polarOffset(angle, DISTANCE), angle)
+
+    doPeriodicallyTimed(INTERVAL, DURATION) cb ->
+        angle += (INTERVAL_SPEED).fromDeg()
+        var dpos = pos.polarOffset(angle, DISTANCE)
+        dummy.setXY(dpos)
+
+        forUnitsInRange(dummy.getPos(), RADIUS) u ->
+            if u.getOwner().isEnemyOf(owner) and not u.hasAbility(BUFF_ID)
+                InstantDummyCaster.castTarget(owner, DUMMY_ABILITY_ID, 1, Orders.thunderbolt, u, dpos)
+        if cb.isLast()
+            dummy.kill()
+
+init
+    registerSpellEffectEvent(ABILITY_ID, () -> onCast())

--- a/wurst/classes/mage/elementalist/Electromagnet.wurst
+++ b/wurst/classes/mage/elementalist/Electromagnet.wurst
@@ -1,0 +1,39 @@
+package Electromagnet
+import RegisterEvents
+import ClosureTimers
+import ClosureForGroups
+
+@configurable constant int ABILITY_ID = 'A04N'
+@configurable constant real MAX_PULL_SPEED = 400
+@configurable constant real PULL_RADIUS = 700
+@configurable constant real MIN_PULL_DISTANCE = 80
+@configurable constant real INTERVAL = 0.03125000
+@configurable constant real DURATION = 1.00
+
+constant SPEED = MAX_PULL_SPEED * INTERVAL
+constant RADIUS = PULL_RADIUS * PULL_RADIUS // avoid square root
+constant MIN_DISTANCE = MIN_PULL_DISTANCE * MIN_PULL_DISTANCE // avoid square root
+
+function onCast()
+    var caster = GetSpellAbilityUnit()
+    var owner = caster.getOwner()
+    var pos = caster.getPos()
+
+    doPeriodicallyTimed(INTERVAL, DURATION) cb ->
+        forUnitsInRange(pos, PULL_RADIUS) u ->
+            var id = u.getTypeId()
+            if u.isAlive() and u.getOwner().isEnemyOf(owner)
+                    and not (u.isType(UNIT_TYPE_STRUCTURE) or u.isType(UNIT_TYPE_FLYING))
+                    and not (id == UNIT_MAMMOTH or id == UNIT_DISCO_DUCK)
+
+                var upos = u.getPos()
+                var dvec = pos - upos
+                var distance = dvec.dot(dvec)
+
+                if distance > MIN_DISTANCE
+                    var speed = max((distance / RADIUS), 0.35) * SPEED
+                    var resultPos = upos.polarOffset(upos.angleTo(pos), speed)
+                    u.setXY(resultPos)
+
+init
+    registerSpellEffectEvent(ABILITY_ID, () -> onCast())

--- a/wurst/classes/mage/elementalist/Eruption.wurst
+++ b/wurst/classes/mage/elementalist/Eruption.wurst
@@ -1,0 +1,25 @@
+package Eruption
+import RegisterEvents
+import ClosureTimers
+import ClosureForGroups
+
+@configurable constant int ABILITY_ID = 'A04Q'
+@configurable constant real RADIUS = 315
+@configurable constant real DAMAGE_AMOUNT = 40
+@configurable constant string EFFECT_PATH = "Abilities\\Spells\\Human\\FlameStrike\\FlameStrike1.mdl"
+
+function onCast()
+    var caster = GetSpellAbilityUnit()
+    var owner = caster.getOwner()
+    var pos = caster.getPos()
+
+    var efx = addEffect(EFFECT_PATH, pos)
+    doAfter(3, () -> efx.destr())
+
+    doAfter(0.5) ->
+        forUnitsInRange(pos, RADIUS) u ->
+            if u.isAlive() and u.getOwner().isEnemyOf(owner) and not u.isType(UNIT_TYPE_STRUCTURE)
+                caster.damageTarget(u, DAMAGE_AMOUNT, ATTACK_TYPE_NORMAL)
+
+init
+    registerSpellEffectEvent(ABILITY_ID, () -> onCast())

--- a/wurst/classes/mage/elementalist/SplittingFlame.wurst
+++ b/wurst/classes/mage/elementalist/SplittingFlame.wurst
@@ -1,0 +1,22 @@
+package SplittingFlame
+import RegisterEvents
+import ClosureTimers
+import ClosureForGroups
+import InstantDummyCaster
+import Orders
+
+@configurable constant int ABILITY_ID = 'A04T'
+@configurable constant int DUMMY_ABILITY_ID = 'A01T'
+@configurable constant real RADIUS = 800
+
+function onCast()
+    var caster = GetSpellAbilityUnit()
+    var owner = caster.getOwner()
+
+    doAfter(1) ->
+        forUnitsInRange(caster.getPos(), RADIUS) u ->
+            if u.isAlive() and u.getOwner().isEnemyOf(owner) and not u.isType(UNIT_TYPE_STRUCTURE) and not u.isType(UNIT_TYPE_FLYING)
+                InstantDummyCaster.castImmediate(owner, DUMMY_ABILITY_ID, 1, Orders.fanofknives, u.getPos())
+
+init
+    registerSpellEffectEvent(ABILITY_ID, () -> onCast())

--- a/wurst/classes/mage/elementalist/StormEarthFire.wurst
+++ b/wurst/classes/mage/elementalist/StormEarthFire.wurst
@@ -1,0 +1,25 @@
+package StormEarthFire
+import RegisterEvents
+import ClosureForGroups
+import Orders
+import InstantDummyCaster
+
+@configurable constant int ABILITY_ID = 'A02G'
+@configurable constant int STORM_ABILITY_ID = 'ACfl'
+@configurable constant int EARTH_ABILITY_ID = 'A017'
+@configurable constant int FIRE_ABILITY_ID = 'ACtb'
+@configurable constant real RADIUS = 512
+
+function onCast()
+    var caster = GetSpellAbilityUnit()
+    var owner = caster.getOwner()
+    var pos = caster.getPos()
+
+    forUnitsInRange(pos, RADIUS) u ->
+        if u.isAlive() and u.isType(UNIT_TYPE_HERO) and u.getOwner().isEnemyOf(owner)
+            InstantDummyCaster.castTarget(owner, EARTH_ABILITY_ID, 1, Orders.entanglingroots, u, pos)
+            InstantDummyCaster.castTarget(owner, FIRE_ABILITY_ID, 1, Orders.creepthunderbolt, u, pos)
+            InstantDummyCaster.castTarget(owner, STORM_ABILITY_ID, 1, Orders.forkedlightning, u, pos)
+
+init
+    registerSpellEffectEvent(ABILITY_ID, () -> onCast())

--- a/wurst/classes/mage/hypnotist/DepressionOrb.wurst
+++ b/wurst/classes/mage/hypnotist/DepressionOrb.wurst
@@ -1,0 +1,45 @@
+package DepressionOrb
+import RegisterEvents
+import Orders
+import InstantDummyCaster
+import ClosureTimers
+import ClosureForGroups
+import EventHelper
+
+@configurable constant int ABILITY_ID = 'A04R'
+@configurable constant int DUMMY_ABILITY_ID = 'A025'
+@configurable constant int DUMMY_ID = UNIT_LOCUST
+@configurable constant int BUFF_ID = DEST_SUPER_TREE
+@configurable constant real INTERVAL = 0.05
+@configurable constant real DURATION = 3
+@configurable constant real TURN_SPEED = 360
+@configurable constant real MOVE_SPEED = 275
+@configurable constant real START_DISTANCE = 50
+@configurable constant real TURN_DISTANCE = 100
+@configurable constant real RADIUS = 400
+
+constant INTERVAL_TURN_SPEED = INTERVAL * TURN_SPEED
+constant INTERVAL_MOVE_SPEED = INTERVAL * MOVE_SPEED
+
+function onCast()
+    var caster = GetSpellAbilityUnit()
+    var owner = caster.getOwner()
+    var pos = caster.getPos()
+    var angle = pos.angleTo(getSpellTargetPos())
+    var dummyAngle = angle(0)
+    var dummy = createUnit(owner, DUMMY_ID, pos.polarOffset(angle, START_DISTANCE), dummyAngle)
+
+    doPeriodicallyTimed(INTERVAL, DURATION) cb ->
+        dummyAngle += (INTERVAL_TURN_SPEED).fromDeg()
+        pos = pos.polarOffset(angle, INTERVAL_MOVE_SPEED)
+        var dpos = pos.polarOffset(dummyAngle, TURN_DISTANCE)
+        dummy.setXY(dpos)
+
+        forUnitsInRange(dummy.getPos(), RADIUS) u ->
+            if not u.hasAbility(BUFF_ID)
+                InstantDummyCaster.castTarget(owner, DUMMY_ABILITY_ID, 1, Orders.acidbomb, u, dpos)
+        if cb.isLast()
+            dummy.kill()
+
+init
+    registerSpellEffectEvent(ABILITY_ID, () -> onCast())

--- a/wurst/classes/mage/hypnotist/DreamEater.wurst
+++ b/wurst/classes/mage/hypnotist/DreamEater.wurst
@@ -1,0 +1,28 @@
+package DreamEater
+import RegisterEvents
+import SimError
+
+@configurable constant int ABILITY_ID = 'A04Z'
+@configurable constant int BUFF_ID = 'BOvd'
+@configurable constant string EFFECT_PATH = "Abilities\\Spells\\Items\\AIso\\AIsoTarget.mdl"
+
+function onStartCast()
+    if GetSpellAbilityId() == ABILITY_ID and not GetSpellTargetUnit().hasAbility(BUFF_ID)
+        GetSpellAbilityUnit().abortOrder()
+        simError(GetTriggerPlayer(), "Target is not dreaming.")
+
+function onCast()
+    var target = GetSpellTargetUnit()
+    target.addEffect(EFFECT_PATH, "overhead").destr()
+    target.subHP(20)
+
+    var value = target.getMana() - 50
+    target.setMana(max(value, 10))
+
+    var caster = GetSpellAbilityUnit()
+    caster.addHP(50)
+    caster.addMana(50)
+
+init
+    registerSpellEffectEvent(ABILITY_ID, () -> onCast())
+    registerPlayerUnitEvent(EVENT_PLAYER_UNIT_SPELL_CAST, () -> onStartCast())

--- a/wurst/classes/mage/hypnotist/Hypnosis.wurst
+++ b/wurst/classes/mage/hypnotist/Hypnosis.wurst
@@ -1,0 +1,12 @@
+package Hypnosis
+import RegisterEvents
+
+@configurable constant int ABILITY_ID = 'A04Y'
+
+function onCast()
+    var target = GetSpellTargetUnit()
+    target.subHP(20)
+    target.addMana(75)
+
+init
+    registerSpellEffectEvent(ABILITY_ID, () -> onCast())

--- a/wurst/classes/mage/hypnotist/Jealousy.wurst
+++ b/wurst/classes/mage/hypnotist/Jealousy.wurst
@@ -1,0 +1,55 @@
+package Jealousy
+import RegisterEvents
+import LinkedList
+import Orders
+import Table
+import ClosureTimers
+import ClosureForGroups
+
+@configurable constant int ABILITY_ID = 'A051'
+@configurable constant real INTERVAL = 0.05
+@configurable constant real CURSE_RADIUS = 800
+@configurable constant real CURSE_DURATION = 10
+
+constant table = new Table()
+
+function onCast()
+    var target = GetSpellTargetUnit()
+    var owner = target.getOwner()
+    var pos = target.getPos()
+    var bewitched = new LinkedList<int>()
+
+    doPeriodicallyTimed(INTERVAL, CURSE_DURATION) cb ->
+        bewitched.forEach(idx -> table.removeHandle(idx))
+
+        if not target.isAlive()
+            cb.stop()
+            destroy bewitched
+        else if cb.isLast()
+            destroy bewitched
+        else
+            bewitched.clear()
+            forUnitsInRange(pos, CURSE_RADIUS) u ->
+                var index = u.getHandleId()
+                if u != target and u.isAlive() and u.getOwner().isAllyOf(owner) and not table.hasHandle(index)
+                    bewitched.push(index)
+                    table.saveUnit(index, target)
+                    u.issueTargetOrderById(Orders.attack, target)
+
+function onAnyOrder()
+    var u = GetTriggerUnit()
+    var index = u.getHandleId()
+
+    if table.hasHandle(index)
+        var target = table.loadUnit(index)
+        if target.isAlive()
+            let t = getPlayerUnitEventTrigger(EVENT_PLAYER_UNIT_ISSUED_TARGET_ORDER)
+            t.disable()
+            u.issueTargetOrderById(Orders.attack, target)
+            t.enable()
+
+init
+    registerSpellEffectEvent(ABILITY_ID, () -> onCast())
+    registerPlayerUnitEvent(EVENT_PLAYER_UNIT_ISSUED_ORDER, () -> onAnyOrder())
+    registerPlayerUnitEvent(EVENT_PLAYER_UNIT_ISSUED_POINT_ORDER, () -> onAnyOrder())
+    registerPlayerUnitEvent(EVENT_PLAYER_UNIT_ISSUED_TARGET_ORDER, () -> onAnyOrder())

--- a/wurst/classes/mage/hypnotist/Seizures.wurst
+++ b/wurst/classes/mage/hypnotist/Seizures.wurst
@@ -1,0 +1,24 @@
+package Seizures
+import RegisterEvents
+import ClosureTimers
+import InstantDummyCaster
+import Orders
+
+@configurable constant int ABILITY_ID = 'A05T'
+@configurable constant int DUMMY_ABILITY_ID = 'A05U'
+
+function startPeriodicAction(player owner, unit target, real timeout, int chance)
+    doPeriodicallyTimed(0.1, timeout) cb ->
+        if GetRandomInt(1, 100) <= chance
+            InstantDummyCaster.castTarget(owner, DUMMY_ABILITY_ID, 1, Orders.thunderbolt, target)
+
+function onCast()
+    var target = GetSpellTargetUnit()
+    var owner = GetSpellAbilityUnit().getOwner()
+
+    startPeriodicAction(owner, target, 3, 18)
+    doAfter(3, () -> startPeriodicAction(owner, target, 3, 15))
+    doAfter(6, () -> startPeriodicAction(owner, target, 2, 8))
+
+init
+    registerSpellEffectEvent(ABILITY_ID, () -> onCast())

--- a/wurst/classes/mage/hypnotist/StupefyAura.wurst
+++ b/wurst/classes/mage/hypnotist/StupefyAura.wurst
@@ -1,0 +1,21 @@
+package StupefyAura
+import RegisterEvents
+
+@configurable constant int ABILITY_ID = 'A05W'
+@configurable constant int AURA_ABILITY_ID = 'A05V'
+
+function onCast()
+    var caster = GetSpellAbilityUnit()
+    if not caster.hasAbility(AURA_ABILITY_ID)
+        caster.addAbility(AURA_ABILITY_ID)
+
+function onEndcast()
+    var caster = GetSpellAbilityUnit()
+    if GetSpellAbilityId() == ABILITY_ID and caster.hasAbility(AURA_ABILITY_ID)
+        caster.removeAbility(AURA_ABILITY_ID)
+        caster.removeAbility('B00L')
+        caster.removeAbility('B00M')
+
+init
+    registerSpellEffectEvent(ABILITY_ID, () -> onCast())
+    registerPlayerUnitEvent(EVENT_PLAYER_UNIT_SPELL_ENDCAST, () -> onEndcast())


### PR DESCRIPTION
Following spells have been rewritten from Jass to Wurst:
Mage:
- Depress, Metronome and ReduceFood.

Hypnotist:
- DepressionOrb, DreamEater, Hypnosis, Jealousy, Seizures and StupefyAura

Elementalist:
- DefenderOrb, Electromagnet, Eruption, SplittingFlame and StormEarthFire

Dementia:
- ActivateRunes, DarkGate and RuneRing

All obsolete Jass equivalents have their register-actions commented out. Removal
of these scripts is scheduled for future patch.

(cherry picked from commit 6d873917e4beb0dca9c3e1c279775362bb401cf0)