### PR TITLE
Fixed bug that prevented modes from affecting food gain, e.g. -lavish and -famine

### DIFF
--- a/wurst/systems/units/hostiles/Hostile.wurst
+++ b/wurst/systems/units/hostiles/Hostile.wurst
@@ -32,7 +32,7 @@ public abstract class Hostile extends UnitEntity
 
     override function onDeath()
         let pos = getPos()
-        let numCorpses = getNumCorpses()
+        let numCorpses = (getNumCorpses() * udg_FOOD_FOR_KILL_PROPORTION).round()
 
         for i = 1 to numCorpses
             createCorpse(players[PLAYER_NEUTRAL_AGGRESSIVE], UNIT_MEAT, pos, randomAngle())


### PR DESCRIPTION
The global wasnt accounted for in meat drop calculations