### PR TITLE
Fixed Replenish Health

### DIFF
--- a/wurst/systems/spells/priest/ReplenishHealth.wurst
+++ b/wurst/systems/spells/priest/ReplenishHealth.wurst
@@ -5,24 +5,25 @@ import UnitEntity
 import MasterHealer
 import Sage
 
-let SPELL_REPLENISH_HEALTH = 'A0F2'
+let ABILITY_ID_REPLENISH_HEALTH_EFFECT = 'A0F2'
+let ABILITY_ID_REPLENISH_HEALTH = 'A0F3'
 
 function onCast()
     let caster = GetTriggerUnit()
     let entity = UnitEntity.findForUnit(caster)
-    if entity instanceof MasterHealer or entity instanceof Sage
+    if not caster.hasAbility(ABILITY_ID_REPLENISH_HEALTH)
         return
 
     switch GetIssuedOrderId()
         case Orders.immolation
-            caster.addAbility(SPELL_REPLENISH_HEALTH)
+            caster.addAbility(ABILITY_ID_REPLENISH_HEALTH_EFFECT)
         case Orders.unimmolation
-            caster.removeAbility(SPELL_REPLENISH_HEALTH)
+            caster.removeAbility(ABILITY_ID_REPLENISH_HEALTH_EFFECT)
 
 function onDeath()
     let caster = GetTriggerUnit()
-    if caster.hasAbility(SPELL_REPLENISH_HEALTH)
-        caster.removeAbility(SPELL_REPLENISH_HEALTH)
+    if caster.hasAbility(ABILITY_ID_REPLENISH_HEALTH_EFFECT)
+        caster.removeAbility(ABILITY_ID_REPLENISH_HEALTH_EFFECT)
 
 init
     registerPlayerUnitEvent(EVENT_PLAYER_UNIT_ISSUED_ORDER, function onCast)

--- a/wurst/systems/spells/priest/ReplenishHealth.wurst
+++ b/wurst/systems/spells/priest/ReplenishHealth.wurst
@@ -2,8 +2,6 @@ package ReplenishHealth
 import RegisterEvents
 import Orders
 import UnitEntity
-import MasterHealer
-import Sage
 
 let ABILITY_ID_REPLENISH_HEALTH_EFFECT = 'A0F2'
 let ABILITY_ID_REPLENISH_HEALTH = 'A0F3'


### PR DESCRIPTION
https://github.com/island-troll-tribes/island-troll-tribes/issues/243

Replenish health simply used to detect order ID of immolation and unimmolation and activate based on that. Gatherer salve recipe dummy abilities had the same ID which lead to gatherer being able to have permanent replenish health effect on. The code also looked like it would not work at all for Master Healer and Sage