### PR TITLE
Wurst item spawning

### DIFF
--- a/wurst/__legacy__/spawns/Spawns.jurst
+++ b/wurst/__legacy__/spawns/Spawns.jurst
@@ -1,4 +1,4 @@
-library Spawns initializer onInit requires Game, ID, TerrainPathability, LegacyTriggers, Elk, Panther, Wolf, Bear, Snake, TerrainUtils, Hawk, GreenFish, Fish
+library Spawns initializer onInit requires Game, ID, TerrainPathability, LegacyTriggers, Elk, Panther, Wolf, Bear, Snake, TerrainUtils, Hawk, GreenFish, Fish, ResourceSpawns
 
 public function modStats takes nothing returns nothing
     set udg_CLAYBALL_RATE = RMinBJ(1.85,udg_CLAYBALL_RATE+0.3)
@@ -57,197 +57,6 @@ function makeFish takes nothing returns nothing
         call makeAFish(gg_rct_fish_new_8)
         set i=i+1
     endloop
-endfunction
-
-function spawnIslandOne takes itempool p returns nothing
-    local integer temp=1
-    local item q
-    local real x=1
-    local real y=1
-    local rect loc = null
-    if((udg_ITEM_CURRENT<udg_ITEM_MAX) or (udg_ITEM_LIMIT_MODE==false)) then
-        set udg_ITEM_CURRENT=udg_ITEM_CURRENT+1
-        call PolledWait( udg_DELAY_TIME )
-        set temp=GetRandomInt(1,udg_ISLAND1_1+udg_ISLAND1_2+udg_ISLAND1_3)
-        if ( temp<=udg_ISLAND1_3 ) then
-            set loc=gg_rct_spawn_area_1_3
-        elseif (temp<=udg_ISLAND1_2+udg_ISLAND1_3) then
-            set loc=gg_rct_spawn_area_1_2
-        elseif (temp<=udg_ISLAND1_1+udg_ISLAND1_2+udg_ISLAND1_3) then
-            set loc=gg_rct_spawn_area_1_1
-        endif
-        if loc != null then
-            loop
-                set x = GetRandomReal(GetRectMinX(loc), GetRectMaxX(loc))
-                set y = GetRandomReal(GetRectMinY(loc), GetRectMaxY(loc))
-                exitwhen IsTerrainLand(x, y) and IsTerrainWalkable(x, y)
-            endloop
-            set q=PlaceRandomItem(p,x,y)
-        endif
-    endif
-    set q=null
-    set loc=null
-endfunction
-
-function spawnIslandTwo takes itempool p returns nothing
-    local integer temp=1
-    local item q
-    local real x=1
-    local real y=1
-    local rect loc = null
-    if((udg_ITEM_CURRENT<udg_ITEM_MAX) or (udg_ITEM_LIMIT_MODE==false)) then
-        set udg_ITEM_CURRENT=udg_ITEM_CURRENT+1
-        call PolledWait( udg_DELAY_TIME )
-        set temp=GetRandomInt(1,udg_ISLAND2_1+udg_ISLAND2_2+udg_ISLAND2_3)
-        if ( temp<=udg_ISLAND2_3 ) then
-            set loc=gg_rct_spawn_area_2_3
-        elseif (temp<=udg_ISLAND2_3+udg_ISLAND2_2) then
-            set loc=gg_rct_spawn_area_2_2
-        elseif (temp<=udg_ISLAND2_1+udg_ISLAND2_2+udg_ISLAND2_3) then
-            set loc=gg_rct_spawn_area_2_1
-        endif
-        if loc != null then
-            loop
-                set x = GetRandomReal(GetRectMinX(loc), GetRectMaxX(loc))
-                set y = GetRandomReal(GetRectMinY(loc), GetRectMaxY(loc))
-                exitwhen IsTerrainLand(x, y) and IsTerrainWalkable(x, y)
-            endloop
-            set q=PlaceRandomItem(p,x,y)
-        endif
-    endif
-    set loc=null
-    set q=null
-endfunction
-
-function spawnIslandThree takes itempool p returns nothing
-    local integer temp=1
-    local item q
-    local real x=1
-    local real y=1
-    local rect loc = null
-    if((udg_ITEM_CURRENT<udg_ITEM_MAX) or (udg_ITEM_LIMIT_MODE==false)) then
-        set udg_ITEM_CURRENT=udg_ITEM_CURRENT+1
-        call PolledWait( udg_DELAY_TIME )
-        set temp=GetRandomInt(1,udg_ISLAND3_1+udg_ISLAND3_2+udg_ISLAND3_3)
-        if ( temp<=udg_ISLAND3_2 ) then
-            set loc=gg_rct_spawn_area_3_2
-        elseif (temp<=udg_ISLAND3_2+udg_ISLAND3_3) then
-            set loc=gg_rct_spawn_area_3_3
-        elseif (temp<=udg_ISLAND3_1+udg_ISLAND3_2+udg_ISLAND3_3) then
-            set loc=gg_rct_spawn_area_3_1
-        endif
-        if loc != null then
-            loop
-                set x = GetRandomReal(GetRectMinX(loc), GetRectMaxX(loc))
-                set y = GetRandomReal(GetRectMinY(loc), GetRectMaxY(loc))
-                exitwhen IsTerrainLand(x, y) and IsTerrainWalkable(x, y)
-            endloop
-            set q=PlaceRandomItem(p,x,y)
-        endif
-    endif
-    set loc=null
-    set q=null
-endfunction
-
-function spawnIslandFour takes itempool p returns nothing
-    local integer temp=1
-    local item q
-    local real x=1
-    local real y=1
-    local rect loc = null
-    if((udg_ITEM_CURRENT<udg_ITEM_MAX) or (udg_ITEM_LIMIT_MODE==false)) then
-        set udg_ITEM_CURRENT=udg_ITEM_CURRENT+1
-        call PolledWait( udg_DELAY_TIME )
-        set temp=GetRandomInt(1,udg_ISLAND4_1+udg_ISLAND4_2+udg_ISLAND4_3)
-        if ( temp<=udg_ISLAND4_2 ) then
-            set loc=gg_rct_spawn_area_4_2
-        elseif (temp<=udg_ISLAND4_2+udg_ISLAND4_3) then
-            set loc=gg_rct_spawn_area_4_3
-        elseif (temp<=udg_ISLAND4_3+udg_ISLAND4_2+udg_ISLAND4_1) then
-            set loc=gg_rct_spawn_area_4_1
-        endif
-        if loc != null then
-            loop
-                set x = GetRandomReal(GetRectMinX(loc), GetRectMaxX(loc))
-                set y = GetRandomReal(GetRectMinY(loc), GetRectMaxY(loc))
-                exitwhen IsTerrainLand(x, y) and IsTerrainWalkable(x, y)
-            endloop
-            set q=PlaceRandomItem(p,x,y)
-        endif
-    endif
-    set loc=null
-    set q=null
-endfunction
-
-//WOW Long spawning Function. CHange pool values for rarity
-function spawnItems takes nothing returns nothing
-    local itempool p=CreateItemPool()
-    local integer i=GetRandomInt(1, 25)
-    local integer loopStart
-    local integer loopStop
-    local integer temp=1
-    local real rndX=1
-    local real y=1
-    local integer spawnCount=0
-    local integer curIsland
-    local item q
-    call ItemPoolAddItemType(p,ITEM_TINDER,udg_TINDER_RATE)
-    call ItemPoolAddItemType(p,ITEM_FLINT,udg_FLINT_RATE)
-    call ItemPoolAddItemType(p,ITEM_STICK,udg_STICK_RATE)
-    call ItemPoolAddItemType(p,ITEM_CLAY_BALL,udg_CLAYBALL_RATE)
-    call ItemPoolAddItemType(p,ITEM_STONE,udg_ROCK_RATE)
-    call ItemPoolAddItemType(p,ITEM_MANA_CRYSTAL,udg_MANACRYSTAL_RATE)
-    call ItemPoolAddItemType(p,ITEM_MUSHROOM,udg_MUSHROOM_RATE)
-    //magic
-    call ItemPoolAddItemType(p,ITEM_MAGIC,.25)
-    set curIsland=GetRandomInt(0,3)
-
-    loop
-        exitwhen spawnCount>3
-
-        if(curIsland==0) then
-            set loopStart=1
-            set loopStop=R2I(udg_NORTH_LEFT_ITEM*udg_SPAWN_BASE)
-            loop
-                exitwhen loopStart > loopStop
-                call spawnIslandOne(p)
-                set loopStart = loopStart + 1
-            endloop
-        endif
-        if(curIsland==1) then
-            set loopStop=R2I(udg_NORTH_RIGHT_ITEM*udg_SPAWN_BASE)
-            set loopStart=1
-            loop
-                exitwhen loopStart > loopStop
-                call spawnIslandTwo(p)
-                set loopStart = loopStart + 1
-            endloop
-        endif
-        if(curIsland==2) then
-            set loopStop=R2I(udg_SOUTH_RIGHT_ITEM*udg_SPAWN_BASE)
-            set loopStart=1
-            loop
-                exitwhen loopStart > loopStop
-                call spawnIslandThree(p)
-                set loopStart = loopStart + 1
-            endloop
-        endif
-        if(curIsland==3) then
-            set loopStop=R2I(udg_SOUTH_LEFT_ITEM*udg_SPAWN_BASE)
-            set loopStart=1
-            loop
-                exitwhen loopStart > loopStop
-                call spawnIslandFour(p)
-                set loopStart = loopStart + 1
-            endloop
-        endif
-        set curIsland=ModuloInteger(curIsland+1,4)
-        set spawnCount=spawnCount+1
-    endloop
-
-    call modStats()
-    set p=null
-	set q=null
 endfunction
 
 function makeAnimal takes rect loc returns nothing
@@ -343,7 +152,7 @@ endfunction
 
 function spawn()
     modStats()
-    spawnItems()
+    handleItemSpawning()
     spawnAnimals()
     makeFish()
     gg_trg_add_items_to_plants.execute()
@@ -351,7 +160,7 @@ endfunction
 
 function spawnFirst()
     spawnAnimals()
-    spawnItems()
+    handleItemSpawning()
     makeFish()
     gg_trg_add_items_to_plants.execute()
 endfunction

--- a/wurst/__legacy__/spawns/Spawns.jurst
+++ b/wurst/__legacy__/spawns/Spawns.jurst
@@ -1,4 +1,4 @@
-library Spawns initializer onInit requires Game, ID, TerrainPathability, LegacyTriggers, Elk, Panther, Wolf, Bear, Snake, TerrainUtils, Hawk, GreenFish, Fish, ResourceSpawns
+library Spawns initializer onInit requires Game, ID, TerrainPathability, LegacyTriggers, Elk, Panther, Wolf, Bear, Snake, TerrainUtils, Hawk, GreenFish, Fish
 
 public function modStats takes nothing returns nothing
     set udg_CLAYBALL_RATE = RMinBJ(1.85,udg_CLAYBALL_RATE+0.3)
@@ -151,8 +151,6 @@ function spawnAnimals takes nothing returns nothing
 endfunction
 
 function spawn()
-    modStats()
-    handleItemSpawning()
     spawnAnimals()
     makeFish()
     gg_trg_add_items_to_plants.execute()
@@ -160,7 +158,6 @@ endfunction
 
 function spawnFirst()
     spawnAnimals()
-    handleItemSpawning()
     makeFish()
     gg_trg_add_items_to_plants.execute()
 endfunction

--- a/wurst/systems/spawns/ResourceSpawns.wurst
+++ b/wurst/systems/spawns/ResourceSpawns.wurst
@@ -1,0 +1,146 @@
+package ResourceSpawns
+import ID
+import HashMap
+import LinkedList
+import GameTimer
+import Game
+import Interpolation
+import ErrorHandling
+import TerrainUtils
+
+let itemSpawnInfoMap = new IterableMap<int, ItemSpawnInfo>()
+let islandSpawnList = new LinkedList<IslandSpawner>()
+var gameStartTime = 0.
+
+class ItemSpawnInfo
+    int itemId
+    real initialSpawnWeight
+    real finalSpawnWeight
+    real weightChangeTime
+    int spawnedCount = 0
+    construct(int itemId, real initialSpawnWeight, real finalSpawnWeight, real weightChangeTime)
+        this.itemId = itemId
+        this.initialSpawnWeight = initialSpawnWeight
+        this.finalSpawnWeight = finalSpawnWeight
+        this.weightChangeTime = weightChangeTime
+        itemSpawnInfoMap.put(itemId, this)
+
+    function getTimeAdjustedSpawnWeight() returns real
+        var ratio = max(1, (getElapsedGameTime() - gameStartTime) / this.weightChangeTime)
+        let spawnWeightAdjusted = linear(initialSpawnWeight, finalSpawnWeight, ratio)
+        return spawnWeightAdjusted
+
+class WeightedSpawnRegion
+    rect reg
+    int weight
+    construct(rect reg, int weight)
+        this.reg = reg
+        this.weight = weight
+
+class IslandSpawner
+    private LinkedList<WeightedSpawnRegion> spawnRegionsList = new LinkedList<WeightedSpawnRegion>()
+    int itemsSpawnCount
+    int animalsSpawnCount
+    real totalRegionsWeight = 0
+
+    construct(int itemsSpawnCount, int animalsSpawnCount, LinkedList<WeightedSpawnRegion> spawnRegionsList)
+        this.itemsSpawnCount = itemsSpawnCount
+        this.animalsSpawnCount = animalsSpawnCount
+        this.spawnRegionsList = spawnRegionsList
+        for r in this.spawnRegionsList
+            totalRegionsWeight += r.weight
+        islandSpawnList.push(this)
+
+    function spawnItemFromPool(itempool itemPool)
+        rect spawnRect = pickWeightedSpawnRect()
+        while true
+            vec2 spawnPoint = spawnRect.randomPoint()
+            if spawnPoint.isTerrainLand() and spawnPoint.isTerrainWalkable()
+                PlaceRandomItem(itemPool, spawnPoint.x, spawnPoint.y)
+                break
+
+    function pickWeightedSpawnRect() returns rect
+        real random = GetRandomReal(0, this.totalRegionsWeight)
+        real randomPickTemporary = 0
+        for r in this.spawnRegionsList
+            randomPickTemporary += r.weight
+            if random <= randomPickTemporary
+                return r.reg
+
+        //Should never end up here
+        error("ERROR: pickWeightedSpawnRect returned null!")
+        return null
+
+    ondestroy
+        for r in this.spawnRegionsList
+            destroy r
+        destroy this.spawnRegionsList
+
+public function handleItemSpawning()
+    let itemPool = CreateItemPool()
+    for itm in itemSpawnInfoMap
+        let spawnInfo = itemSpawnInfoMap.get(itm)
+        ItemPoolAddItemType(itemPool, spawnInfo.itemId, spawnInfo.getTimeAdjustedSpawnWeight())
+
+    let spawnedCount = new HashMap<IslandSpawner, int>()
+    while true
+        //Spawn one item on each island until they all reached the max count
+        bool loopDidSpawn = false
+        for island in islandSpawnList
+            //Abruptly stop loop if item limit reached
+            if (udg_ITEM_LIMIT_MODE and udg_ITEM_CURRENT >= udg_ITEM_MAX)
+                loopDidSpawn = false
+                break
+
+            //Spawn item if island-specific spawn count is not yet achieved
+            if not spawnedCount.has(island) or (spawnedCount.get(island) < island.itemsSpawnCount * udg_ITEM_BASE)
+                island.spawnItemFromPool(itemPool)
+                udg_ITEM_CURRENT += 1
+                loopDidSpawn = true
+
+        //Return when all islandSpawners iterated without any spawns (or abrupt stop condition reached)
+        if not loopDidSpawn
+            break
+
+    DestroyItemPool(itemPool)
+
+function initItemSpawnInfo()
+    new ItemSpawnInfo(ITEM_TINDER, 5, .7, 860)
+    new ItemSpawnInfo(ITEM_CLAY_BALL, 1, 1.85, 340)
+    new ItemSpawnInfo(ITEM_STICK, 3, 4.5, 360)
+    new ItemSpawnInfo(ITEM_FLINT, 3, 2, 300)
+    new ItemSpawnInfo(ITEM_MANA_CRYSTAL, 0, 1.6, 384)
+    new ItemSpawnInfo(ITEM_STONE, 1, 3.3, 552)
+    new ItemSpawnInfo(ITEM_MUSHROOM, 0, 1.2, 360)
+    new ItemSpawnInfo(ITEM_MAGIC, 0.25, 0.25, 1)
+
+function initIslandSpawners()
+    let NWSpawns = new LinkedList<WeightedSpawnRegion>()
+    NWSpawns.add(new WeightedSpawnRegion(gg_rct_spawn_area_1_1, udg_ISLAND1_1))
+    NWSpawns.add(new WeightedSpawnRegion(gg_rct_spawn_area_1_2, udg_ISLAND1_2))
+    NWSpawns.add(new WeightedSpawnRegion(gg_rct_spawn_area_1_3, udg_ISLAND1_3))
+    new IslandSpawner(udg_NORTH_LEFT_ITEM, udg_NORTH_LEFT_FOOD, NWSpawns)
+
+    let NESpawns = new LinkedList<WeightedSpawnRegion>()
+    NWSpawns.add(new WeightedSpawnRegion(gg_rct_spawn_area_2_1, udg_ISLAND2_1))
+    NWSpawns.add(new WeightedSpawnRegion(gg_rct_spawn_area_2_2, udg_ISLAND2_2))
+    NWSpawns.add(new WeightedSpawnRegion(gg_rct_spawn_area_2_3, udg_ISLAND2_3))
+    new IslandSpawner(udg_NORTH_RIGHT_ITEM, udg_NORTH_RIGHT_FOOD, NESpawns)
+
+    let SESpawns = new LinkedList<WeightedSpawnRegion>()
+    NWSpawns.add(new WeightedSpawnRegion(gg_rct_spawn_area_3_1, udg_ISLAND3_1))
+    NWSpawns.add(new WeightedSpawnRegion(gg_rct_spawn_area_3_2, udg_ISLAND3_2))
+    NWSpawns.add(new WeightedSpawnRegion(gg_rct_spawn_area_3_3, udg_ISLAND3_3))
+    new IslandSpawner(udg_SOUTH_RIGHT_ITEM, udg_SOUTH_RIGHT_FOOD, SESpawns)
+
+    let SWSpawns = new LinkedList<WeightedSpawnRegion>()
+    NWSpawns.add(new WeightedSpawnRegion(gg_rct_spawn_area_4_1, udg_ISLAND4_1))
+    NWSpawns.add(new WeightedSpawnRegion(gg_rct_spawn_area_4_2, udg_ISLAND4_2))
+    NWSpawns.add(new WeightedSpawnRegion(gg_rct_spawn_area_4_3, udg_ISLAND4_3))
+    new IslandSpawner(udg_SOUTH_LEFT_ITEM, udg_SOUTH_LEFT_FOOD, SWSpawns)
+
+init
+    initItemSpawnInfo()
+    initIslandSpawners()
+    registerGameStartEvent() ->
+        gameStartTime = getElapsedGameTime()

--- a/wurst/systems/spawns/ResourceSpawns.wurst
+++ b/wurst/systems/spawns/ResourceSpawns.wurst
@@ -216,7 +216,7 @@ init
 
         //First spawns. Do twice to retain original amounts after  halving the items per spawn and doubling cycle frequency.
         handleItemSpawning()
-        doAfter(30) ->
+        doAfter(10) ->
             handleItemSpawning()
 
         startSpawnCycle()

--- a/wurst/systems/spawns/ResourceSpawns.wurst
+++ b/wurst/systems/spawns/ResourceSpawns.wurst
@@ -8,6 +8,7 @@ import Interpolation
 import ErrorHandling
 import TerrainUtils
 import SpawnRateAdjustment
+import ClosureTimers
 
 let itemSpawnInfoMap = new IterableMap<int, ItemSpawnInfo>()
 let islandSpawnList = new LinkedList<IslandSpawner>()
@@ -40,9 +41,12 @@ class WeightedSpawnRegion
         this.weight = weight
 
 class IslandSpawner
-    private LinkedList<WeightedSpawnRegion> spawnRegionsList = new LinkedList<WeightedSpawnRegion>()
+    private let spawnRegionsList = new LinkedList<WeightedSpawnRegion>()
+    private let spawnsPerType = new HashMap<int, int>()
     int itemsSpawnCount
     int animalsSpawnCount
+    int spawnedTotal = 0
+    itempool itemPool = null
     real totalRegionsWeight = 0
 
     construct(int itemsSpawnCount, int animalsSpawnCount, LinkedList<WeightedSpawnRegion> spawnRegionsList)
@@ -53,13 +57,56 @@ class IslandSpawner
             totalRegionsWeight += r.weight
         islandSpawnList.push(this)
 
-    function spawnItemFromPool(itempool itemPool)
+    function spawnItemFromPool()
+        if this.itemPool == null
+            error("ERROR: spawnItemFromPool tried to spawn without having a generated pool!")
+            return
+
         rect spawnRect = pickWeightedSpawnRect()
         while true
             vec2 spawnPoint = spawnRect.randomPoint()
             if spawnPoint.isTerrainLand() and spawnPoint.isTerrainWalkable()
-                PlaceRandomItem(itemPool, spawnPoint.x, spawnPoint.y)
+                let spawnedItem = PlaceRandomItem(itemPool, spawnPoint.x, spawnPoint.y)
+
+                //Keep track of spawned total & spawned item type total to balance out spawning
+                this.spawnedTotal += 1
+                let spawnedType = spawnedItem.getTypeId()
+                if not this.spawnsPerType.has(spawnedType)
+                    this.spawnsPerType.put(spawnedType, 1)
+                else
+                    this.spawnsPerType.put(spawnedType, this.spawnsPerType.get(spawnedType) + 1)
+
                 break
+
+    function generateItemPool()
+        /*
+        This function generates an island-specific itempool with adjusted weights according to how much current state of spawned items
+        differs from what the adjusted weights are.
+
+        For example, if there is less flints than the amount of flints that the spawn ratios try to aim for, we increase flint spawns by up to 50% depending on how much behind the spawns are
+        */
+        if this.itemPool != null
+            DestroyItemPool(this.itemPool)
+
+        this.itemPool = CreateItemPool()
+        var totalWeight = 0.
+        for i in itemSpawnInfoMap
+            totalWeight += itemSpawnInfoMap.get(i).getTimeAdjustedSpawnWeight()
+
+        for itm in itemSpawnInfoMap
+            let spawnInfo = itemSpawnInfoMap.get(itm)
+            let itemWeight = spawnInfo.getTimeAdjustedSpawnWeight()
+            let weightRatio = itemWeight / totalWeight
+            var adjustmentRatio = 1.
+            if this.spawnedTotal != 0
+                let itemRatio = this.spawnsPerType.get(itm) / this.spawnedTotal
+                let difference = (weightRatio-itemRatio).abs()
+                if itemRatio < weightRatio
+                    adjustmentRatio = linear(1, 1.5, max(1, (difference / 0.5)))
+                else if itemRatio > weightRatio
+                    adjustmentRatio = linear(1, 0.5, max(1, (difference / 0.5)))
+
+            ItemPoolAddItemType(itemPool, spawnInfo.itemId, itemWeight * adjustmentRatio)
 
     function pickWeightedSpawnRect() returns rect
         real random = GetRandomReal(0, this.totalRegionsWeight)
@@ -77,34 +124,34 @@ class IslandSpawner
         for r in this.spawnRegionsList
             destroy r
         destroy this.spawnRegionsList
+        destroy this.spawnsPerType
 
 public function handleItemSpawning()
-    let itemPool = CreateItemPool()
-    for itm in itemSpawnInfoMap
-        let spawnInfo = itemSpawnInfoMap.get(itm)
-        ItemPoolAddItemType(itemPool, spawnInfo.itemId, spawnInfo.getTimeAdjustedSpawnWeight())
+    for island in islandSpawnList
+        island.generateItemPool()
 
     let spawnedCount = new HashMap<IslandSpawner, int>()
-    while true
+    doPeriodically(ANIMATION_PERIOD) spawnLoop ->
         //Spawn one item on each island until they all reached the max count
         bool loopDidSpawn = false
         for island in islandSpawnList
             //Abruptly stop loop if item limit reached
             if (udg_ITEM_LIMIT_MODE and udg_ITEM_CURRENT >= udg_ITEM_MAX)
                 loopDidSpawn = false
-                break
+                destroy spawnLoop //Break
 
             //Spawn item if island-specific spawn count is not yet achieved
             if not spawnedCount.has(island) or (spawnedCount.get(island) < island.itemsSpawnCount * udg_ITEM_BASE)
-                island.spawnItemFromPool(itemPool)
+                island.spawnItemFromPool()
                 udg_ITEM_CURRENT += 1
+                spawnedCount.put(island, spawnedCount.get(island) + 1)
                 loopDidSpawn = true
+                PolledWait(ANIMATION_PERIOD)
 
         //Return when all islandSpawners iterated without any spawns (or abrupt stop condition reached)
         if not loopDidSpawn
-            break
+            destroy spawnLoop //Break
 
-    DestroyItemPool(itemPool)
 
 function initItemSpawnInfo()
     new ItemSpawnInfo(ITEM_TINDER, 5, .7, 860)
@@ -124,21 +171,21 @@ function initIslandSpawners()
     new IslandSpawner(udg_NORTH_LEFT_ITEM, udg_NORTH_LEFT_FOOD, NWSpawns)
 
     let NESpawns = new LinkedList<WeightedSpawnRegion>()
-    NWSpawns.add(new WeightedSpawnRegion(gg_rct_spawn_area_2_1, udg_ISLAND2_1))
-    NWSpawns.add(new WeightedSpawnRegion(gg_rct_spawn_area_2_2, udg_ISLAND2_2))
-    NWSpawns.add(new WeightedSpawnRegion(gg_rct_spawn_area_2_3, udg_ISLAND2_3))
+    NESpawns.add(new WeightedSpawnRegion(gg_rct_spawn_area_2_1, udg_ISLAND2_1))
+    NESpawns.add(new WeightedSpawnRegion(gg_rct_spawn_area_2_2, udg_ISLAND2_2))
+    NESpawns.add(new WeightedSpawnRegion(gg_rct_spawn_area_2_3, udg_ISLAND2_3))
     new IslandSpawner(udg_NORTH_RIGHT_ITEM, udg_NORTH_RIGHT_FOOD, NESpawns)
 
     let SESpawns = new LinkedList<WeightedSpawnRegion>()
-    NWSpawns.add(new WeightedSpawnRegion(gg_rct_spawn_area_3_1, udg_ISLAND3_1))
-    NWSpawns.add(new WeightedSpawnRegion(gg_rct_spawn_area_3_2, udg_ISLAND3_2))
-    NWSpawns.add(new WeightedSpawnRegion(gg_rct_spawn_area_3_3, udg_ISLAND3_3))
+    SESpawns.add(new WeightedSpawnRegion(gg_rct_spawn_area_3_1, udg_ISLAND3_1))
+    SESpawns.add(new WeightedSpawnRegion(gg_rct_spawn_area_3_2, udg_ISLAND3_2))
+    SESpawns.add(new WeightedSpawnRegion(gg_rct_spawn_area_3_3, udg_ISLAND3_3))
     new IslandSpawner(udg_SOUTH_RIGHT_ITEM, udg_SOUTH_RIGHT_FOOD, SESpawns)
 
     let SWSpawns = new LinkedList<WeightedSpawnRegion>()
-    NWSpawns.add(new WeightedSpawnRegion(gg_rct_spawn_area_4_1, udg_ISLAND4_1))
-    NWSpawns.add(new WeightedSpawnRegion(gg_rct_spawn_area_4_2, udg_ISLAND4_2))
-    NWSpawns.add(new WeightedSpawnRegion(gg_rct_spawn_area_4_3, udg_ISLAND4_3))
+    SWSpawns.add(new WeightedSpawnRegion(gg_rct_spawn_area_4_1, udg_ISLAND4_1))
+    SWSpawns.add(new WeightedSpawnRegion(gg_rct_spawn_area_4_2, udg_ISLAND4_2))
+    SWSpawns.add(new WeightedSpawnRegion(gg_rct_spawn_area_4_3, udg_ISLAND4_3))
     new IslandSpawner(udg_SOUTH_LEFT_ITEM, udg_SOUTH_LEFT_FOOD, SWSpawns)
 
 init

--- a/wurst/systems/spawns/ResourceSpawns.wurst
+++ b/wurst/systems/spawns/ResourceSpawns.wurst
@@ -131,7 +131,9 @@ public function handleItemSpawning()
         island.generateItemPool()
 
     let spawnedCount = new HashMap<IslandSpawner, int>()
-    doPeriodically(ANIMATION_PERIOD) spawnLoop ->
+
+    //Use animation period * 2 since the old system was WAY slower than this
+    doPeriodically(ANIMATION_PERIOD*2) spawnLoop ->
         //Spawn one item on each island until they all reached the max count
         bool loopDidSpawn = false
         for island in islandSpawnList
@@ -146,12 +148,12 @@ public function handleItemSpawning()
                 udg_ITEM_CURRENT += 1
                 spawnedCount.put(island, spawnedCount.get(island) + 1)
                 loopDidSpawn = true
-                PolledWait(ANIMATION_PERIOD)
 
         //Return when all islandSpawners iterated without any spawns (or abrupt stop condition reached)
         if not loopDidSpawn
             destroy spawnLoop //Break
 
+    destroy spawnedCount
 
 function initItemSpawnInfo()
     new ItemSpawnInfo(ITEM_TINDER, 5, .7, 860)
@@ -188,6 +190,23 @@ function initIslandSpawners()
     SWSpawns.add(new WeightedSpawnRegion(gg_rct_spawn_area_4_3, udg_ISLAND4_3))
     new IslandSpawner(udg_SOUTH_LEFT_ITEM, udg_SOUTH_LEFT_FOOD, SWSpawns)
 
+function startSpawnCycle()
+    doPeriodically(120) spawnerCallback ->
+        handleItemSpawning()
+        adjustBaseSpawnrates()
+
+function adjustBaseSpawnrates()
+    //Replacement for modStats function of the legacy system.
+    //Dynamically adjust overall item & animal amounts (and specific item type amounts but that is handled by the itemSpawnInfo class now)
+    udg_ITEM_BASE = max(.15,udg_ITEM_BASE-0.2)
+    udg_FOOD_BASE = max(.15,udg_FOOD_BASE-0.2)
+
+    // This part actually doesnt do anythin since udg_BADDIE_BASE is always 1.00 - Keeping it for now to be safe
+    udg_PANTHER_RATE = R2I(1*udg_BADDIE_BASE)
+    udg_BEAR_RATE = R2I(1*udg_BADDIE_BASE)
+    udg_SNAKE_RATE = R2I(1*udg_BADDIE_BASE)
+    udg_WOLF_RATE = R2I(2*udg_BADDIE_BASE)
+
 init
     initIslandWeights()
     initSpawnRegionWeights()
@@ -195,3 +214,10 @@ init
     initIslandSpawners()
     registerGameStartEvent() ->
         gameStartTime = getElapsedGameTime()
+
+        //First spawns. Do twice to retain original amounts after  halving the items per spawn and doubling cycle frequency.
+        handleItemSpawning()
+        doAfter(30) ->
+            handleItemSpawning()
+
+        startSpawnCycle()

--- a/wurst/systems/spawns/ResourceSpawns.wurst
+++ b/wurst/systems/spawns/ResourceSpawns.wurst
@@ -140,7 +140,7 @@ public function handleItemSpawning()
             //Abruptly stop loop if item limit reached
             if (udg_ITEM_LIMIT_MODE and udg_ITEM_CURRENT >= udg_ITEM_MAX)
                 loopDidSpawn = false
-                destroy spawnLoop //Break
+                break
 
             //Spawn item if island-specific spawn count is not yet achieved
             if not spawnedCount.has(island) or (spawnedCount.get(island) < island.itemsSpawnCount * udg_ITEM_BASE)
@@ -151,9 +151,8 @@ public function handleItemSpawning()
 
         //Return when all islandSpawners iterated without any spawns (or abrupt stop condition reached)
         if not loopDidSpawn
+            destroy spawnedCount
             destroy spawnLoop //Break
-
-    destroy spawnedCount
 
 function initItemSpawnInfo()
     new ItemSpawnInfo(ITEM_TINDER, 5, .7, 860)

--- a/wurst/systems/spawns/ResourceSpawns.wurst
+++ b/wurst/systems/spawns/ResourceSpawns.wurst
@@ -7,6 +7,7 @@ import Game
 import Interpolation
 import ErrorHandling
 import TerrainUtils
+import SpawnRateAdjustment
 
 let itemSpawnInfoMap = new IterableMap<int, ItemSpawnInfo>()
 let islandSpawnList = new LinkedList<IslandSpawner>()
@@ -26,7 +27,8 @@ class ItemSpawnInfo
         itemSpawnInfoMap.put(itemId, this)
 
     function getTimeAdjustedSpawnWeight() returns real
-        var ratio = max(1, (getElapsedGameTime() - gameStartTime) / this.weightChangeTime)
+        //Clamp ratio between 0 - 1 with min & max
+        var ratio = min(0, max(1, (getElapsedGameTime() - gameStartTime) / this.weightChangeTime))
         let spawnWeightAdjusted = linear(initialSpawnWeight, finalSpawnWeight, ratio)
         return spawnWeightAdjusted
 
@@ -140,6 +142,8 @@ function initIslandSpawners()
     new IslandSpawner(udg_SOUTH_LEFT_ITEM, udg_SOUTH_LEFT_FOOD, SWSpawns)
 
 init
+    initIslandWeights()
+    initSpawnRegionWeights()
     initItemSpawnInfo()
     initIslandSpawners()
     registerGameStartEvent() ->

--- a/wurst/systems/spawns/SpawnRateAdjustment.wurst
+++ b/wurst/systems/spawns/SpawnRateAdjustment.wurst
@@ -1,4 +1,4 @@
-package ResourceSpawning
+package SpawnRateAdjustment
 
 /*      WALKABLEAREA    RELATIVE TO ISLAND
 1_1 =   20660034        65%

--- a/wurst/systems/spawns/SpawnRateAdjustment.wurst
+++ b/wurst/systems/spawns/SpawnRateAdjustment.wurst
@@ -34,7 +34,7 @@ TOTAL AREA OF ALL SPAWN AREAS
 */
 
 
-function initSpawnRegionWeights()
+public function initSpawnRegionWeights()
     //Based on data from Analysis.Wurst
     //These weights result in the same item density in every region
     //These must be re-calculated if the regions are modified
@@ -52,7 +52,7 @@ function initSpawnRegionWeights()
     udg_ISLAND4_2 = 7
     udg_ISLAND4_3 = 5
 
-function initIslandWeights()
+public function initIslandWeights()
     //These values tell how many iterations of item / animal spawns an island gets
     //These should be balanced according to total area an of islands spawn regions
     //relative to the whole maps all spawn regions
@@ -82,7 +82,3 @@ function initIslandWeights()
     udg_NORTH_RIGHT_FOOD = (FOOD_TOTAL * ne_Area_Relative).round()
     udg_SOUTH_RIGHT_FOOD = (FOOD_TOTAL * se_Area_Relative).round()
     udg_SOUTH_LEFT_FOOD = (FOOD_TOTAL * sw_Area_Relative).round()
-
-init
-    initIslandWeights()
-    initSpawnRegionWeights()

--- a/wurst/systems/spawns/SpawnRateAdjustment.wurst
+++ b/wurst/systems/spawns/SpawnRateAdjustment.wurst
@@ -56,14 +56,14 @@ public function initIslandWeights()
     //These values tell how many iterations of item / animal spawns an island gets
     //These should be balanced according to total area an of islands spawn regions
     //relative to the whole maps all spawn regions
-    //Original values
-    var NORTH_LEFT_ITEM=30
+
+    var NORTH_LEFT_ITEM=15
     var NORTH_LEFT_FOOD=9
-    var NORTH_RIGHT_ITEM=33
+    var NORTH_RIGHT_ITEM=17
     var NORTH_RIGHT_FOOD=10
-    var SOUTH_RIGHT_ITEM=30
+    var SOUTH_RIGHT_ITEM=15
     var SOUTH_RIGHT_FOOD=10
-    var SOUTH_LEFT_ITEM=45
+    var SOUTH_LEFT_ITEM=23
     var SOUTH_LEFT_FOOD=17
     var ITEM_TOTAL = NORTH_LEFT_ITEM+NORTH_RIGHT_ITEM+SOUTH_RIGHT_ITEM+SOUTH_LEFT_ITEM
     var FOOD_TOTAL = NORTH_LEFT_FOOD+NORTH_RIGHT_FOOD+SOUTH_RIGHT_FOOD+SOUTH_LEFT_FOOD


### PR DESCRIPTION
Started work on wurstifying all the spawn systems, beginning with the item spawning system.

This system also includes small pseudorandomization to even out the item spawns. For example if less flints spawned than the average amount should have been, the next spawn cycle will get up to 50% adjustment ratio to the spawnrate of flints to try and steer it towards the average.