### PR TITLE
Fixed blowgun item bounce on load

### DIFF
--- a/wurst.build
+++ b/wurst.build
@@ -4,7 +4,7 @@ dependencies:
 - "https://github.com/wurstscript/wurstStdlib2"
 - "https://github.com/crojewsk/wurstExtLibs.git"
 buildMapData:
-  name: "Island Troll Tribes goldtest3"
-  fileName: "Island Troll Tribes goldtest3"
+  name: "Island Troll Tribes Beta 21"
+  fileName: "Island Troll Tribes Beta 21"
   author: "Quazz"
   playerCount: 12

--- a/wurst/_items/Blowgun.wurst
+++ b/wurst/_items/Blowgun.wurst
@@ -14,6 +14,7 @@ import ErrorHandling
 import ID
 import UnitExtensions
 import ObjectIds
+import ClosureTimers
 
 constant let ICON = Icons.bTNAlleriaFlute
 constant let ITEM_TOOLTIP = "Purchase |cffffcc00B|rlow Gun"
@@ -183,7 +184,8 @@ class Blowpipe
         if _chargesToLoad == 0
             //Bounce item to stop slot swap from happening
             owner.removeItem(itm)
-            owner.addItemHandle(itm)
+            nullTimer() ->
+                owner.addItemHandle(itm)
             return
 
         //Load the appropriate amount of charges
@@ -203,7 +205,8 @@ class Blowpipe
 
             //Bounce item to stop slot swap from happening
             owner.removeItem(itm)
-            owner.addItemHandle(itm)
+            nullTimer() ->
+                owner.addItemHandle(itm)
 
         updateTooltip()
 


### PR DESCRIPTION
Small fix to blowgun loading so the item doesnt swap slots with the ammunition if trying to load a full blowgun