### PR TITLE
Blowgun ammo contents tooltip suffix removed

### DIFF
--- a/wurst/_items/Blowgun.wurst
+++ b/wurst/_items/Blowgun.wurst
@@ -219,7 +219,7 @@ class Blowpipe
                 var charges = itm.getCharges()
                 if (charges == 0)
                     charges = 1
-                ammoString = ammoString + "\n" + itm.getName() + " x" + charges.toString() + "|r"
+                ammoString = ammoString + "\n" + itm.getName() + "|r"
 
         this.i.setExtendedTooltip(ITEM_TOOLTIP_EXT + ammoString)
 


### PR DESCRIPTION
Now that the itemcount system changes item names to for example, "Thistles (x3)" the blowgun was showing this twice such as "Thistles (x3) x3". Now the blowgun no longer adds a suffix of its own when listing ammo contained.