### PR TITLE
Updated -ms command, now give ms of the selected unit

### DIFF
--- a/wurst/__legacy__/lib/CheatPack.jurst
+++ b/wurst/__legacy__/lib/CheatPack.jurst
@@ -792,7 +792,7 @@ library CheatPack initializer onInit requires Game, GameConfig
             call DisplayTimedTextToPlayer(p2p,0,0,10,"-hp # - Sets # health points to selected hero")
         elseif SubString(s2s,0,6)=="-list2" then
             call DisplayTimedTextToPlayer(p2p,0,0,10,"-mp # - Sets # mana points to selected hero")
-            call DisplayTimedTextToPlayer(p2p,0,0,10,"-ms # - Sets # move speed to selected hero")
+            call DisplayTimedTextToPlayer(p2p,0,0,10,"-mos # - Sets # move speed to selected hero")
             call DisplayTimedTextToPlayer(p2p,0,0,10,"-additem # - Spawns # random items")
             call DisplayTimedTextToPlayer(p2p,0,0,10,"-invul - Makes selected units invulnerable")
             call DisplayTimedTextToPlayer(p2p,0,0,10,"-vul - Makes selected units vulnerable")
@@ -985,7 +985,7 @@ library CheatPack initializer onInit requires Game, GameConfig
                 call SetUnitInvulnerable(u2u,false)
             elseif SubString(s2s,0,5)=="-kill" then
                 call SetWidgetLife(u2u,0)
-            elseif SubString(s2s,0,3)=="-ms" then
+            elseif SubString(s2s,0,3)=="-mos" then
                 call SetUnitMoveSpeed(u2u,I2R(z2z))
             elseif SubString(s2s,0,7)=="-pathon" then
                 call SetUnitPathing(u2u,true)

--- a/wurst/systems/commands/Commands.wurst
+++ b/wurst/systems/commands/Commands.wurst
@@ -3,6 +3,7 @@ import LinkedList
 import ChatCommands
 import StringExtensions
 import PlayerExtensions
+import UnitExtensions
 import ChatUtils
 import Game
 import GameMode
@@ -95,11 +96,19 @@ init
         registerCommandAll("p", (triggerPlayer, args) -> handlePlayerAllianceSettingToggle(triggerPlayer, args))
 
         registerCommandAll("ms") (triggerPlayer, args) ->
-            let hero = triggerPlayer.getTroll()
-            if hero.isAlive()
-                let msg = "Your movement speed is {0}".format(hero.getMoveSpeed().toString().color(ENERGY_COLOR))
+            let units = CreateGroup()..enumUnitsSelected(triggerPlayer, null)
+            if units.isEmpty()
+                let hero = triggerPlayer.getTroll()
+                if hero.isAlive()
+                let msg = "{0} the {1} movement speed is {2}".format(hero.getProperName().color(HIGHLIGHT_COLOR), hero.getName().color(SPECIAL_COLOR), hero.getMoveSpeed().toString().color(HIGHLIGHT_COLOR))
                 printTimedToPlayer(msg, 5, triggerPlayer)
-
+            else
+                for u in units
+                    if u.isTroll()
+                        let msg = "{0} the {1} movement speed is {2}".format(u.getProperName().color(HIGHLIGHT_COLOR), u.getName().color(SPECIAL_COLOR), u.getMoveSpeed().toString().color(HIGHLIGHT_COLOR))
+                        printTimedToPlayer(msg, 5, triggerPlayer)
+            units.destr()
+                
         registerCommandAll("cc") (triggerPlayer, args) ->
             let id = args.get(1).toInt() mod 12
             let msg = "Adjusted player color to {0}Player {1}|r".format(id.toPlayerColor().toColor().toColorString(), (id + 1).toString())


### PR DESCRIPTION
Awar triggered me with a movement speed conversation, so I add to check it out ingame, realized -ms doesn't work very well in -dev mode.
I think this would be better :
![mscmdupdate](https://user-images.githubusercontent.com/7768858/52528222-2dd57500-2cd9-11e9-8e88-77b01c913a25.jpg)