### PR TITLE
Ensnared hostile will now abort the move order

### DIFF
--- a/wurst/systems/commands/Commands.wurst
+++ b/wurst/systems/commands/Commands.wurst
@@ -103,7 +103,7 @@ init
                     let msg = "{0} the {1} movement speed is {2}".format(hero.getProperName().color(HIGHLIGHT_COLOR), hero.getName().color(SPECIAL_COLOR), hero.getMoveSpeed().toString().color(HIGHLIGHT_COLOR))
                     printTimedToPlayer(msg, 5, triggerPlayer)
             else
-                for u in units
+                for u from units
                     if u.isTroll()
                         let msg = "{0} the {1} movement speed is {2}".format(u.getProperName().color(HIGHLIGHT_COLOR), u.getName().color(SPECIAL_COLOR), u.getMoveSpeed().toString().color(HIGHLIGHT_COLOR))
                         printTimedToPlayer(msg, 5, triggerPlayer)

--- a/wurst/systems/commands/SpawningTestHelpers.wurst
+++ b/wurst/systems/commands/SpawningTestHelpers.wurst
@@ -46,3 +46,8 @@ init
                                 break
                     else
                         simError(triggerPlayer, "Cannot spawn {0}".format(idStr))
+
+            registerCommandAll("hostile") (triggerPlayer, args) ->
+                let units = CreateGroup()..enumUnitsSelected(triggerPlayer, null)
+                for u in units
+                    u.setOwner(players[PLAYER_NEUTRAL_AGGRESSIVE], true)

--- a/wurst/systems/commands/SpawningTestHelpers.wurst
+++ b/wurst/systems/commands/SpawningTestHelpers.wurst
@@ -49,6 +49,6 @@ init
 
             registerCommandAll("hostile") (triggerPlayer, args) ->
                 let units = CreateGroup()..enumUnitsSelected(triggerPlayer, null)
-                for u in units
+                for u from units
                     u.setOwner(players[PLAYER_NEUTRAL_AGGRESSIVE], true)
                 units.destr()

--- a/wurst/systems/commands/SpawningTestHelpers.wurst
+++ b/wurst/systems/commands/SpawningTestHelpers.wurst
@@ -51,3 +51,4 @@ init
                 let units = CreateGroup()..enumUnitsSelected(triggerPlayer, null)
                 for u in units
                     u.setOwner(players[PLAYER_NEUTRAL_AGGRESSIVE], true)
+                units.destr()

--- a/wurst/systems/spawns/HostileNetBehavior.wurst
+++ b/wurst/systems/spawns/HostileNetBehavior.wurst
@@ -5,6 +5,7 @@ import ID
 
 constant let MOVE_ORDER = String2OrderIdBJ("move")
 
+
 function onCast()
     let target = GetSpellTargetUnit()
 
@@ -19,5 +20,8 @@ function onCast()
                 target.abortOrder()
 
 init
+    //Hunter & ensnare ability
     registerSpellEffectEvent('Aweb', () -> onCast())
+
+    //Nets item ability
     registerSpellEffectEvent('Aens', () -> onCast())

--- a/wurst/systems/spawns/HostileNetBehavior.wurst
+++ b/wurst/systems/spawns/HostileNetBehavior.wurst
@@ -1,0 +1,23 @@
+package HostileNetBehavior
+import ClosureTimers
+import RegisterEvents
+import ID
+
+constant let MOVE_ORDER = String2OrderIdBJ("move")
+
+function onCast()
+    let target = GetSpellTargetUnit()
+
+    if target.getOwner() == players[PLAYER_NEUTRAL_AGGRESSIVE] and target.isType(UNIT_TYPE_GROUND)
+         and target.getCurrentOrder() == MOVE_ORDER and target.getTypeId() != UNIT_ELK
+        doAfter(0.5) ->
+            if target.isAlive()
+                target.abortOrder()
+        //After approximatively 5 seconds, there is a move order issued, since net last 10 seconds, we need to abort this order too
+        doAfter(6) ->
+            if target.isAlive()
+                target.abortOrder()
+
+init
+    registerSpellEffectEvent('Aweb', () -> onCast())
+    registerSpellEffectEvent('Aens', () -> onCast())

--- a/wurst/systems/spawns/HostileNetBehavior.wurst
+++ b/wurst/systems/spawns/HostileNetBehavior.wurst
@@ -2,15 +2,13 @@ package HostileNetBehavior
 import ClosureTimers
 import RegisterEvents
 import ID
-
-constant let MOVE_ORDER = String2OrderIdBJ("move")
-
+import Orders
 
 function onCast()
     let target = GetSpellTargetUnit()
 
     if target.getOwner() == players[PLAYER_NEUTRAL_AGGRESSIVE] and target.isType(UNIT_TYPE_GROUND)
-         and target.getCurrentOrder() == MOVE_ORDER and target.getTypeId() != UNIT_ELK
+         and target.getCurrentOrder() == Orders.move and target.getTypeId() != UNIT_ELK
         doAfter(0.5) ->
             if target.isAlive()
                 target.abortOrder()


### PR DESCRIPTION
From what I saw, creep behavior seems to issue an move order back to initial position after ~6 seconds.
Made small bunch of code which will abort the move order when the unit's being targeted by ensnare ability.
![showcase](https://thumbs.gfycat.com/UnimportantBasicAxolotl-size_restricted.gif)

Also added a "-hostile" command to give selected unit to PLAYER_NEUTRAL_AGGRESSIVE