### PR TITLE
Added ScoreBoard

### DIFF
--- a/wurst/_units/TrollUnitTextConstant.wurst
+++ b/wurst/_units/TrollUnitTextConstant.wurst
@@ -2,16 +2,16 @@ package TrollUnitTextConstant
 
 import LegacyColors
 import ID
+import Assets
 import ObjectIds
-import MeatSystem
 import EatRawMeat
 import LinkedList
 import HashMap
 import IdListConstant
-import MagicMist
 
 // Custom Models
-public constant  CUSTOM_MODEL_PATH = "Models\\"
+public constant CUSTOM_MODEL_PATH = "Models\\"
+public constant CUSTOM_ICON_PATH = "ReplaceableTextures\\CommandButtons\\BTN{0}.blp"
 
 public constant  M_SPY                     = CUSTOM_MODEL_PATH+"Spy.mdx"
 public constant  M_SAGE                    = CUSTOM_MODEL_PATH+"Sage.mdx"
@@ -289,3 +289,43 @@ public constant  TOOLTIP_SPY             = "The Spy got the best radar and revea
 
 public constant  TOOLTIP_OMNIGATHERER    = "The Omni Gatherer got all the gatherer abilities possible, he can also warp items around him when he gets lazy."
                                             +DIFFICULTY_EASY
+
+public constant trollIcons = new HashMap<int, string>()
+..put(UNIT_HUNTER, Icons.bTNForestTroll)
+..put(UNIT_HUNTER_1, Icons.bTNForestTroll)
+..put(UNIT_TRACKER, Icons.bTNIceTroll)
+..put(UNIT_WARRIOR, CUSTOM_ICON_PATH.format("TrollPredator"))
+..put(UNIT_JUGGERNAUT, CUSTOM_ICON_PATH.format("TrollPredator"))
+..put(UNIT_BEAST_MASTER, Icons.bTNShaman)
+..put(UNIT_BEAST_MASTER_1, Icons.bTNShaman)
+..put(UNIT_SHAPESHIFTER_WOLF, Icons.bTNDireWolf)
+..put(UNIT_SHAPESHIFTER_BEAR, Icons.bTNGrizzlyBear)
+..put(UNIT_SHAPESHIFTER_PANTHER, CUSTOM_ICON_PATH.format("Panther"))
+..put(UNIT_SHAPESHIFTER_TIGER, CUSTOM_ICON_PATH.format("Tiger"))
+..put(UNIT_CHICKEN_FORM, Icons.bTNCritterChicken)
+..put(UNIT_ULTIMATE_FORM, Icons.bTNJungleBeast)
+..put(UNIT_MAGE, Icons.bTNWitchDoctor)
+..put(UNIT_MAGE_1, Icons.bTNWitchDoctor)
+..put(UNIT_ELEMENTALIST, Icons.bTNIceTrollShaman)
+..put(UNIT_ELEMENTALIST_1, Icons.bTNIceTrollShaman)
+..put(UNIT_ELEMENTALIST_NEW, Icons.bTNIceTrollShaman)
+..put(UNIT_HYPNOTIST, CUSTOM_ICON_PATH.format("Hypnotist"))
+..put(UNIT_DEMENTIA_MASTER, Icons.bTNDarkTrollShadowPriest)
+..put(UNIT_PRIEST, Icons.bTNShadowHunter)
+..put(UNIT_BOOSTER, Icons.bTNForestTrollShadowPriest)
+..put(UNIT_BOOSTER_1, Icons.bTNForestTrollShadowPriest)
+..put(UNIT_MASTER_HEALER, CUSTOM_ICON_PATH.format("MasterHealer"))
+..put(UNIT_MASTER_HEALER_1, CUSTOM_ICON_PATH.format("MasterHealer"))
+..put(UNIT_SAGE, Icons.bTNForestTrollShadowPriest)
+..put(UNIT_THIEF, Icons.bTNDarkTrollTrapper)
+..put(UNIT_ESCAPE_ARTIST, Icons.bTNDarkTroll)
+..put(UNIT_CONTORTIONIST, CUSTOM_ICON_PATH.format("Contortionist"))
+..put(UNIT_ASSASSIN, Icons.bTNDarkTrollTrapper)
+..put(UNIT_SCOUT, CUSTOM_ICON_PATH.format("Scout"))
+..put(UNIT_OBSERVER, CUSTOM_ICON_PATH.format("ObserverSentry"))
+..put(UNIT_TRAPPER, CUSTOM_ICON_PATH.format("Trapper"))
+..put(UNIT_SPY, Icons.bTNForestTrollTrapper)
+..put(UNIT_GATHERER, CUSTOM_ICON_PATH.format("Gatherer"))
+..put(UNIT_RADAR_GATHERER, CUSTOM_ICON_PATH.format("TerrorTroll"))
+..put(UNIT_HERB_MASTER, Icons.bTNIceTrollShadowPriest)
+..put(UNIT_OMNIGATHERER, CUSTOM_ICON_PATH.format("TerrorTroll"))

--- a/wurst/systems/boards/ObserverBoard.wurst
+++ b/wurst/systems/boards/ObserverBoard.wurst
@@ -1,7 +1,7 @@
 package ObserverBoard
 import LinkedList
 import Tribe
-import GameMode
+import Game
 import PlayerExtensions
 import PublicLibrary
 import StringUtils
@@ -11,6 +11,7 @@ import Lodash
 import DialogExtensions
 import RegisterEvents
 import Dialog
+import ScoreBoard
 
 let OPTION_NAME_COLOR = colorA(180, 180, 180, 255)
 let OPTION_VALUE_COLOR = colorA(115, 152, 255, 255)
@@ -179,14 +180,16 @@ function getObservers() returns LinkedList<player>
     return observers
 
 init
-    GameMode.onModeSelectionFinish() ->
+    registerGameStartEvent() ->
         let observers = getObservers()
         for observer in observers
-            let options = asList<ObserverBoardControl>(
-                new ObserverBoardVisionControl(observer),
-                new ObserverBoardZoomControl(observer)
-            )
-            new ObserverBoard(observer, options)
+            nullTimer() () ->
+                ScoreBoard.board.display(observer, true)
+            // let options = asList<ObserverBoardControl>(
+            //     new ObserverBoardVisionControl(observer),
+            //     new ObserverBoardZoomControl(observer)
+            // )
+            // new ObserverBoard(observer, options)
 
         destroy observers
 

--- a/wurst/systems/boards/PlayerScore.wurst
+++ b/wurst/systems/boards/PlayerScore.wurst
@@ -1,0 +1,148 @@
+package PlayerScore
+
+import HashMap
+import LinkedList
+import ID
+import Tribe
+import ChatCommands
+import ClosureEvents
+import Game
+import DamageEvent
+import UnitExtensions
+import HealingSystem
+import LegacyColors
+import ClosureTimers
+
+public constant animalName = new IterableMap<int, string>()
+..put(UNIT_ELK, "Elk" )
+..put(UNIT_HAWK, "Hawk" )
+..put(UNIT_SNAKE, "Snake" )
+..put(UNIT_JUNGLE_WOLF, "Jungle Wolf" )
+..put(UNIT_JUNGLE_BEAR, "Jungle Bear" )
+..put(UNIT_PANTHER, "Panther" )
+
+public let playerScores = new HashMap<player, PlayerScore>
+
+/**
+Store the player's animals kill count, damage dealt to troll, healing done to ally and gold acquired from selling stuff
+**/
+class PlayerScore
+
+    static function createScoreMap()
+        let tribes = Tribe.getTribes()
+
+        for tribe in tribes
+            for member in tribe.getMembers()
+                playerScores.put(member, new PlayerScore(member))
+
+    static function initialize()
+        registerTribeInitializationFinishEvent(function createScoreMap)
+
+    IterableMap<LinkedList<int>, int> playerKill
+    int damageTroll = 0
+    int healTroll = 0
+    int meatEaten = 0
+    int goldAmount = 0
+    int previousGoldAmount = 0
+    player _player
+
+    construct(player _player)
+        this._player = _player
+        playerKill = new IterableMap<LinkedList<int>, int>()
+        ..put(asList(UNIT_ELK, UNIT_ELK_ADOLESCENT, UNIT_ADULT_ELK), 0)
+        ..put(asList(UNIT_HAWK, UNIT_HAWK_ADOLESCENT, UNIT_ALPHA_HAWK), 0)
+        ..put(asList(UNIT_SNAKE), 0)
+        ..put(asList(UNIT_JUNGLE_WOLF, UNIT_ADULT_JUNGLE_WOLF), 0)
+        ..put(asList(UNIT_JUNGLE_BEAR, UNIT_ADULT_JUNGLE_BEAR), 0)
+        ..put(asList(UNIT_PANTHER, UNIT_ELDER_PANTHER), 0)
+
+    function addGold()
+        previousGoldAmount = _player.getLumber()
+        //nulltimer neccessary here to get the gold before the sold event gold are added to the player
+        nullTimer() ->
+            goldAmount += _player.getLumber() - previousGoldAmount
+
+    //Add healing from the healing system, only priest spells are handled at this moment
+    function addHeal(int heal)
+        healTroll += heal
+
+    function addDamage(int damage)
+        damageTroll += damage
+
+    function addKill(int unitId)
+        for unitType in playerKill
+            if unitType.has(unitId)
+                let killCount = playerKill.get(unitType)
+                playerKill.put(unitType, killCount + 1)
+
+    function addMeatEaten()
+        meatEaten++
+
+    function displayKill()
+        for unitType in playerKill
+            print(playerKill.get(unitType))
+
+    function printScore()
+        var msg = (GOLD_COLOR + "Damage dealt (troll) :  {0}{1}\n|r"+
+                   GOLD_COLOR + "Healing done (allies)  : {0}{2}\n|r"+
+                   GOLD_COLOR + "Gold acquired : {0}{3}\n|r"+
+                   GOLD_COLOR + "Meat Eaten : {0}{4}\n|r"
+                   ).format(SPECIAL_COLOR, damageTroll.toString(), healTroll.toString(), goldAmount.toString(), meatEaten.toString())
+
+        for unitType in playerKill
+            msg += GOLD_COLOR + "{0} kill count : {1}{2}\n|r".format(animalName.get(unitType.getFirst()), SPECIAL_COLOR, playerKill.get(unitType).toString())
+        printTimedToPlayer(msg, 10, _player)
+
+
+init
+    PlayerScore.initialize()
+    registerGameStartEvent() ->
+        EventListener.add(EVENT_PLAYER_UNIT_DEATH) ->
+            let dead = GetDyingUnit()
+            let killerOwner = GetKillingUnit().getOwner()
+            if killerOwner != players[PLAYER_NEUTRAL_AGGRESSIVE]
+                and killerOwner != players[PLAYER_NEUTRAL_PASSIVE]
+                playerScores.get(killerOwner).addKill(dead.getTypeId())
+
+        DamageEvent.addListener() () ->
+            let attackerOwner = DamageEvent.getSource().getOwner()
+            let target = DamageEvent.getTarget()
+            let dmgAmount = DamageEvent.getAmount()
+
+            if attackerOwner != players[PLAYER_NEUTRAL_AGGRESSIVE]
+                and attackerOwner != players[PLAYER_NEUTRAL_PASSIVE]
+                and target.getOwner().isEnemyOf(attackerOwner)
+                and target.isTroll()
+                and playerScores.has(attackerOwner)
+                playerScores.get(attackerOwner).addDamage(dmgAmount.toInt())
+
+        onUnitHealed() ->
+            let instance = getHealingInstance()
+            let caster = instance.getCaster()
+            let target = instance.getTarget()
+
+            if caster != target
+                let healAmount = instance.getAmount()
+                playerScores.get(caster.getOwner()).addHeal(healAmount.toInt())
+
+        EventListener.add(EVENT_PLAYER_UNIT_USE_ITEM) ->
+            let itm = GetManipulatedItem()
+            let itemId = itm.getTypeId()
+            let user = GetManipulatingUnit()
+            let userOwner = user.getOwner()
+
+            if (itemId == ITEM_COOKED_MEAT or itemId == ITEM_SMOKED_MEAT) and user.isTroll() and playerScores.has(userOwner)
+                print(userOwner.getName())
+                playerScores.get(userOwner).addMeatEaten()
+
+        EventListener.add(EVENT_PLAYER_UNIT_SELL_ITEM) ->
+            let owner = GetTriggerUnit().getOwner()
+            playerScores.get(owner).previousGoldAmount = owner.getLumber()
+
+        // Lazy handling, don't work correctly with team gold
+        EventListener.add(EVENT_PLAYER_UNIT_PAWN_ITEM) ->
+            let owner = GetTriggerUnit().getOwner()
+            playerScores.get(owner).addGold()
+
+        registerCommandAll("score") (player triggerPlayer, LinkedList<string> arguments) ->
+            playerScores.get(triggerPlayer).printScore()

--- a/wurst/systems/boards/ScoreBoard.wurst
+++ b/wurst/systems/boards/ScoreBoard.wurst
@@ -1,0 +1,219 @@
+package ScoreBoard
+
+import Game
+import ClosureTimers
+import Boards
+import LinkedList
+import LegacyColors
+import PlayerExtensions
+import HashMap
+import Assets
+import PlayerScore
+import Lodash
+import TrollUnitTextConstant
+
+constant UPDATE_PERIOD = 1.0
+constant KILL_COLUMN_WIDTH = 0.055
+constant STAT_LABEL_WIDTH = 0.09
+
+constant boardItemLabel = asList(new Pair("Elk", Icons.bTNStag),
+                                 new Pair("Hawk", Icons.bTNWarEagle ),
+                                 new Pair("Snake", Icons.bTNWindSerpent ),
+                                 new Pair("Wolf", Icons.bTNTimberWolf ),
+                                 new Pair("Bear", Icons.bTNFrostBear ),
+                                 new Pair("Panther", "ReplaceableTextures\\CommandButtons\\BTNPanther.blp"),
+                                 new Pair("Damage Dealt", Icons.bTNCriticalStrike),
+                                 new Pair("Healing Done", Icons.bTNHeal),
+                                 new Pair("Gold Acquired", Icons.bTNMGExchange),
+                                 new Pair("Meat Eaten", Icons.bTNMonsterLure)
+                                )
+
+/**
+Display players's score on a board, supposed to be displayed to observers
+**/
+public class ScoreBoard
+    static multiboard board = CreateMultiboard()
+    CallbackPeriodic cb
+
+    construct()
+        this.cb = doPeriodically(UPDATE_PERIOD, cb -> updateBoard())
+        createBoard()
+
+    function createBoard()
+        var playerNbr = 0
+        for i = 0 to bj_MAX_PLAYERS - 1
+            if not players[i].isObserver() and players[i].isIngame()
+                playerNbr++
+
+        board
+        ..setColumnCount(12)
+        ..setRowCount(playerNbr + 1)
+        ..setTitle("Score Board")
+        ..display(false)
+        ..minimalize(true)
+
+        createLabel()
+        createBoardContent()
+
+    function createLabel()
+        var row = 0
+        var column = 0
+
+        //First Row
+        //Player Label
+        board
+        .getItem(row, column)
+        ..setStyle(true, false)
+        ..setValue(GOLD_COLOR + "Player")
+        ..setWidth(0.1)
+        ..release()
+        column++
+
+        //Level Label
+        board
+        .getItem(row, column)
+        ..setStyle(true, false)
+        ..setValue(HIGHLIGHT_COLOR + "Level")
+        ..setWidth(0.05)
+        ..release()
+        column++
+
+        //Init Player Kill & Score Label
+        for label in boardItemLabel
+            board
+            .getItem(row, column)
+            ..setStyle(true, true)
+            ..setValue(HIGHLIGHT_COLOR + label.a)
+            ..setIcon(label.b)
+            ..setWidth(column < 8 ? KILL_COLUMN_WIDTH : STAT_LABEL_WIDTH)
+            ..release()
+            column++
+
+    function createBoardContent()
+        var row = 1
+        for i = 0 to bj_MAX_PLAYERS - 1
+            if not players[i].isObserver() and players[i].isIngame()
+                let score = playerScores.get(players[i])
+                var column = 0
+
+                //Player label
+                board
+                .getItem(row, column)
+                ..setStyle(true, false)
+                ..setValue(players[i].getNameColored())
+                ..setWidth(0.1)
+                ..release()
+                column++
+
+                //Level Label
+                board
+                .getItem(row, column)
+                ..setStyle(true, true)
+                ..setWidth(0.05)
+                ..release()
+                column++
+
+                //PlayerKill Label
+                for j = 0 to score.playerKill.size() - 1
+                    board
+                    .getItem(row, column)
+                    ..setStyle(true, false)
+                    ..setWidth(KILL_COLUMN_WIDTH)
+                    ..release()
+                    column++
+
+                //Damage dealt to troll label
+                board
+                .getItem(row, column)
+                ..setStyle(true, false)
+                ..setValueColor(255, 0, 0, 255)
+                ..setWidth(STAT_LABEL_WIDTH)
+                ..release()
+                column++
+
+                //Healing done label
+                board
+                .getItem(row, column)
+                ..setStyle(true, false)
+                ..setValueColor(0, 255, 0, 255)
+                ..setWidth(STAT_LABEL_WIDTH)
+                ..release()
+                column++
+
+                //Gold acquired Label
+                board
+                .getItem(row, column)
+                ..setStyle(true, false)
+                ..setValueColor(255, 255, 0, 255)
+                ..setWidth(STAT_LABEL_WIDTH)
+                ..release()
+                column++
+
+                //Meat eaten Label
+                board
+                .getItem(row, column)
+                ..setStyle(true, false)
+                ..setValueColor(255, 161, 0, 255)
+                ..setWidth(STAT_LABEL_WIDTH)
+                ..release()
+                row++
+
+    function updateBoard()
+        var row = 1
+
+        board.setTitle(getGameTimersBoardTitle())
+
+        for i = 0 to bj_MAX_PLAYERS - 1
+            if not players[i].isObserver() and players[i].isIngame()
+                let score = playerScores.get(players[i])
+                var column = 1
+
+                //Player Level Label
+                board
+                .getItem(row, column)
+                ..setValue(players[i].getTroll().getLevel().toString())
+                ..setIcon(trollIcons.get(players[i].getTroll().getTypeId()))
+                ..release()
+                column++
+
+                //PlayerKill Label
+                for unitType in score.playerKill
+                    board
+                    .getItem(row, column)
+                    ..setValue(score.playerKill.get(unitType).toString())
+                    ..release()
+                    column++
+
+                //Damage dealt to troll label
+                board
+                .getItem(row, column)
+                ..setValue(score.damageTroll.toString())
+                ..release()
+                column++
+
+                //Healing done label
+                board
+                .getItem(row, column)
+                ..setValue(score.healTroll.toString())
+                ..release()
+                column++
+
+                //Gold acquired Label
+                board
+                .getItem(row, column)
+                ..setValue(score.goldAmount.toString())
+                ..release()
+                column++
+
+                //Meat eaten Label
+                board
+                .getItem(row, column)
+                ..setValue(score.meatEaten.toString())
+                ..release()
+
+                row += 1
+
+init
+    registerGameStartEvent() ->
+        nullTimer() ->
+            new ScoreBoard()

--- a/wurst/systems/boards/TribeBoard.wurst
+++ b/wurst/systems/boards/TribeBoard.wurst
@@ -119,9 +119,12 @@ class TribeBoard
 init
     registerGameStartEvent() ->
         nullTimer() ->
-            Tribe.getTribes().each(tribe -> new TribeBoard(tribe))
+            //Need to do this so tribeboard is initialized after scoreBoard, otherwise tribeboard won't display
+            doAfter(0.5) () ->
+                Tribe.getTribes().each(tribe -> new TribeBoard(tribe))
 
         registerPlayerEvent(EVENT_PLAYER_LEAVE) ->
-            TribeBoard
-                .findForPlayer(GetTriggerPlayer())
-                .fixDisplay()
+            if not GetTriggerPlayer().isObserver() and not GetTriggerPlayer().isObserverNew()
+                TribeBoard
+                    .findForPlayer(GetTriggerPlayer())
+                    .fixDisplay()

--- a/wurst/systems/core/HealingSystem.wurst
+++ b/wurst/systems/core/HealingSystem.wurst
@@ -31,6 +31,7 @@ public class HealingInstance
     real amount
     real multiplier
     unit target
+    unit caster
 
     /** Creates a new HealingInstance, fires onUnitHealed events for it and applies the healing after possible event modifications */
     construct(unit target, real amount, HealingType healingType)
@@ -38,6 +39,15 @@ public class HealingInstance
         this.amount = amount
         this.multiplier = 1
         this.target = target
+        this.caster = target
+        execute()
+
+    construct(unit target, unit caster, real amount, HealingType healingType)
+        this.healingType = healingType
+        this.amount = amount
+        this.multiplier = 1
+        this.target = target
+        this.caster = caster
         execute()
 
     private function fireHealingEvent()
@@ -72,5 +82,11 @@ public class HealingInstance
         this.multiplier = max(0, this.multiplier*factor)
         return this.multiplier
 
+    function getAmount() returns real
+        return this.amount
+
     function getTarget() returns unit
         return this.target
+
+    function getCaster() returns unit
+        return this.caster

--- a/wurst/systems/core/Tribe.wurst
+++ b/wurst/systems/core/Tribe.wurst
@@ -8,6 +8,7 @@ import PlayerExtensions
 import LegacyColors
 import GameConfig
 import GameMode
+import initlater ScoreBoard
 
 let listeners = CreateTrigger()
 
@@ -104,7 +105,9 @@ public class Tribe
         return defeated
 
     function makePlayersObservers()
-        getMembers().forEach(member -> member.makeObserver())
+        getMembers().forEach() member ->
+            member.makeObserver()
+            ScoreBoard.board.display(member, true)
 
     function wasDefeated()
         makePlayersObservers()

--- a/wurst/systems/spells/priest/unsub/HealingWave.wurst
+++ b/wurst/systems/spells/priest/unsub/HealingWave.wurst
@@ -66,7 +66,7 @@ class HealingWaveInstance
         waveBounce(target, caster, true)
 
     function waveBounce(unit target, unit previousTarget, bool isFirstBounce)
-        new HealingInstance(target, this.healingAmount, HealingType.ABILITY)
+        new HealingInstance(target, this.caster, this.healingAmount, HealingType.ABILITY)
 
         var lightningFxPath = isFirstBounce ? LIGHTNING_HEALING_WAWE_PRIMARY : LIGHTNING_HEALING_WAWE_SEECONDARY
         attachLightningFX(previousTarget, target, lightningFxPath, 1.5)
@@ -120,19 +120,13 @@ class HealingWaveInstance
     ondestroy
         destroy this.targetsHit
 
+function onCast()
+    var caster = GetSpellAbilityUnit()
+    var target = GetSpellTargetUnit()
+    new HealingWaveInstance(caster, target, HEAL_AMOUNT, BOUNCE_COUNT.toInt())
+
 init
     // Don't know how to make it simplier
-    registerSpellEffectEvent(SPELL_HEALING_WAVE) ->
-        var caster = GetSpellAbilityUnit()
-        var target = GetSpellTargetUnit()
-        new HealingWaveInstance(caster, target, HEAL_AMOUNT, BOUNCE_COUNT.toInt())
-
-    registerSpellEffectEvent(SPELL_MH_HEALING_WAVE) ->
-        var caster = GetSpellAbilityUnit()
-        var target = GetSpellTargetUnit()
-        new HealingWaveInstance(caster, target, HEAL_AMOUNT, BOUNCE_COUNT.toInt())
-
-    registerSpellEffectEvent(SPELL_SAGE_HEALING_WAVE) ->
-        var caster = GetSpellAbilityUnit()
-        var target = GetSpellTargetUnit()
-        new HealingWaveInstance(caster, target, HEAL_AMOUNT, BOUNCE_COUNT.toInt())
+    registerSpellEffectEvent(SPELL_HEALING_WAVE, () ->  onCast())
+    registerSpellEffectEvent(SPELL_MH_HEALING_WAVE, () ->  onCast())
+    registerSpellEffectEvent(SPELL_SAGE_HEALING_WAVE, () ->  onCast())

--- a/wurst/systems/spells/priest/unsub/RangedHeal.wurst
+++ b/wurst/systems/spells/priest/unsub/RangedHeal.wurst
@@ -48,8 +48,9 @@ class RangedHeal extends ChannelAbilityPreset
     new RangedHeal(SPELL_RANGED_HEAL, "R", new Pair(3, 0))
 
 function onCast()
+    var caster = GetSpellAbilityUnit()
     var target = GetSpellTargetUnit()
-    new HealingInstance(target, HEALING_AMOUNT, HealingType.ABILITY)
+    new HealingInstance(target, caster, HEALING_AMOUNT, HealingType.ABILITY)
     let fx = target.addEffect(HEAL_HIT_FX, "origin")
     doAfter(1.5) ->
         fx.destr()


### PR DESCRIPTION
![](https://i.gyazo.com/36a231592a7dc7e816ef24ab196213ea.png)

Damage dealt is the damage dealt to enemy trolls.
Healing done is the amount of heal done by priest ranged heal & healing wave. That's all for now.
Also featuring Meat Eaten count.
I took the liberty of replacing the current observer board with a scoreboard due to issue #352 

ScoreBoard is displayed to defeated players & observers.
Gold Amount Acquired shouldn't work with team gold mode.