### PR TITLE
Improved UX for moving corpses.

### DIFF
--- a/wurst/extensions/PlayerExtensions.wurst
+++ b/wurst/extensions/PlayerExtensions.wurst
@@ -72,4 +72,4 @@ public function player.getZoom() returns real
     return getZoom(this)
 
 public function player.canControl(unit target) returns bool
-    return GetPlayerAlliance(this, target.getOwner(), ALLIANCE_SHARED_CONTROL)
+    return GetPlayerAlliance(target.getOwner(), this, ALLIANCE_SHARED_CONTROL)

--- a/wurst/extensions/PlayerExtensions.wurst
+++ b/wurst/extensions/PlayerExtensions.wurst
@@ -70,3 +70,6 @@ public function player.setZoom(real zoom)
 
 public function player.getZoom() returns real
     return getZoom(this)
+
+public function player.canControl(unit target) returns bool
+    return GetPlayerAlliance(this, target.getOwner(), ALLIANCE_SHARED_CONTROL)

--- a/wurst/lib/commands/Alliances.wurst
+++ b/wurst/lib/commands/Alliances.wurst
@@ -1,0 +1,66 @@
+package Alliances
+
+// Standard library imports:
+import HashMap
+import LinkedList
+
+// Third-party imports:
+import LodashExtensions
+import SimError
+import Toolkit
+
+// TODO: Map strings directly to alliancetype once templating supports that.
+let settings = new IterableMap<string, int>()
+    ..put("ally",     0)
+    ..put("vision",   1)
+    ..put("share",    2)
+    ..put("advanced", 3)
+
+alliancetype array flags
+
+function handleAlliance(player triggerer, LinkedList<string> arguments)
+    // Get the operation requested.
+    let op = arguments.get(0)
+
+    // Compute the target player for the alliance.
+    let input = arguments.size() > 1
+        ? players[arguments.get(1).toInt()]
+        : triggerer
+
+    // Compute whether the source and target should be swapped.
+    // TODO: Actually parse a boolean with typed arguments.
+    let invert = arguments.size() > 2
+
+    // Look up the corresponding flag for the given setting.
+    let setting = flags[settings.get(arguments.get(0))]
+
+    // Compute the source and target.
+    let source = invert ? input : triggerer
+    let target = invert ? triggerer : input
+
+    // Look up the current state of requested alliance.
+    let state = GetPlayerAlliance(source, target, setting)
+
+    // Print a debugging message.
+    // TODO: Use logging.
+    print("Previous value of '{0}' for {1} with {2}: {3}".format(
+        op,
+        source.getName(),
+        target.getName(),
+        state.toString()
+    ))
+
+    // Invert the state.
+    SetPlayerAlliance(source, target, setting, not state)
+
+init
+    // Initialize the array.
+    flags[0] = ALLIANCE_PASSIVE
+    flags[1] = ALLIANCE_SHARED_VISION
+    flags[2] = ALLIANCE_SHARED_CONTROL
+    flags[3] = ALLIANCE_SHARED_ADVANCED_CONTROL
+
+    // Register each command with a shared callback that branches.
+    settings.forEach() (string setting, int index) ->
+        registerToolkitCommand(setting) (triggerer, arguments) ->
+            handleAlliance(triggerer, arguments)

--- a/wurst/lib/commands/ModifySelected.wurst
+++ b/wurst/lib/commands/ModifySelected.wurst
@@ -26,8 +26,8 @@ init
     // Changes the owner for each unit, defaulting to the triggerer.
     registerToolkitCommand("owner") (triggerPlayer, arguments) ->
         // Precompute the new owner based on the command.
-        let owner = arguments.size() > 0
-            ? players[arguments.get(0).toInt()]
+        let owner = arguments.size() > 1
+            ? players[arguments.get(1).toInt()]
             : triggerPlayer
 
         // Modify ownership.

--- a/wurst/lib/commands/ModifySelected.wurst
+++ b/wurst/lib/commands/ModifySelected.wurst
@@ -6,7 +6,6 @@ import ClosureForGroups
 // Third-party imports:
 import Toolkit
 
-
 init
     // Heals each unit fully.
     registerToolkitCommand("heal") (triggerPlayer, arguments) ->

--- a/wurst/objects/abilities/MoveCorpses.wurst
+++ b/wurst/objects/abilities/MoveCorpses.wurst
@@ -139,7 +139,7 @@ let switches = new HashMap<int, int>()
             ..presetCastRange(lvl -> 128)
             ..presetTooltipNormal(lvl -> "|c00ffcc00C|r - Grab Corpse")
             ..presetTooltipNormalExtended(lvl -> "Grabs a nearby corpse and stores it for later use. Unattended corpses will rot after two minutes.|n" + "Current Capacity: {0} / {1}".color(GOLD_COLOR).format(index.toString(), MAX_COUNT.toString()))
-            ..presetTooltipTurnOff(lvl -> "Right-click to begin dropping corpses.".color(ENERGY_COLOR))
+            ..presetTooltipTurnOff(lvl -> "Right-click or hotkey V to begin dropping corpses.".color(ENERGY_COLOR))
 
 // Used to drop meat via a Replenish effect, configured to not affect any units.
 // This ability is used because it has autocast and does not require a target.
@@ -164,7 +164,7 @@ let switches = new HashMap<int, int>()
             ..setName("Drop Corpse")
             ..presetTooltipNormal(lvl -> "|c00ffcc00C|r - Drop Corpse")
             ..presetTooltipNormalExtended(lvl -> "Drops a carried corpse onto the ground.|n" + "Current Capacity: {0} / {1}".color(GOLD_COLOR).format(index.toString(), MAX_COUNT.toString()))
-            ..presetTooltipTurnOff(lvl -> "Right-click to begin grabbing corpses.".color(ENERGY_COLOR))
+            ..presetTooltipTurnOff(lvl -> "Right-click or hotkey V to begin grabbing corpses.".color(ENERGY_COLOR))
 
 
 // Checks whether the unit is able to move corpses.

--- a/wurst/objects/abilities/MoveCorpses.wurst
+++ b/wurst/objects/abilities/MoveCorpses.wurst
@@ -181,6 +181,7 @@ function unit.canMoveCorpses() returns bool
     // Output the failure case.
     return false
 
+// Switches between ability tracks, outputting the new ability ID.
 function switchAbilities(unit target) returns int
     // Look up the state for the unit.
     let count = counts.get(target)
@@ -343,12 +344,9 @@ function onDeath(unit target)
 function onKey(player triggerer)
     // Attempt to switch the ability for each unit selected.
     forUnitsSelected(triggerer) (unit target) ->
-        print("Considering " + target.getName())
         // Check that the action is both legal and valid.
         if triggerer.canControl(target) and target.canMoveCorpses()
-            print("switch abilities.")
             switchAbilities(target)
-
 
 init
     registerPlayerUnitEvent(EVENT_PLAYER_UNIT_SUMMON) ->

--- a/wurst/objects/abilities/MoveCorpses.wurst
+++ b/wurst/objects/abilities/MoveCorpses.wurst
@@ -4,6 +4,7 @@ package MoveCorpses
 import AbilityObjEditing
 import Assets
 import ClosureEvents
+import ClosureForGroups
 import ClosureTimers
 import LastOrder
 import LinkedList
@@ -17,9 +18,15 @@ import Orders
 import ColorUtils
 import DummyCorpse
 import LocalAssets
+import PlayerExtensions
 import SimError
 import StringExtensions
 import Transformation
+
+// The time for which new abilities are disabled to prevent accidental rollback.
+// TODO: Use a per-player setting for this.
+// TODO: Allow lockout to be manually overridden.
+let LOCKOUT = 1.
 
 // The maximum number of corpses allowed to be carried per unit.
 @configurable let MAX_COUNT = 8
@@ -159,7 +166,22 @@ let switches = new HashMap<int, int>()
             ..presetTooltipNormalExtended(lvl -> "Drops a carried corpse onto the ground.|n" + "Current Capacity: {0} / {1}".color(GOLD_COLOR).format(index.toString(), MAX_COUNT.toString()))
             ..presetTooltipTurnOff(lvl -> "Right-click to begin grabbing corpses.".color(ENERGY_COLOR))
 
-function switchAbilities(unit target) returns bool
+
+// Checks whether the unit is able to move corpses.
+// TODO: Support the case where a unit loses the ability to move corpses.
+function unit.canMoveCorpses() returns bool
+    // Check if the unit is currently tracked.
+    if counts.has(this)
+        return true
+
+    // Check if the unit has the original, unused ability.
+    if this.hasAbility(getGrabID.run(0))
+        return true
+
+    // Output the failure case.
+    return false
+
+function switchAbilities(unit target) returns int
     // Look up the state for the unit.
     let count = counts.get(target)
 
@@ -187,7 +209,7 @@ function switchAbilities(unit target) returns bool
         simError(target.getOwner(), message)
 
         // Exit without swapping abilities.
-        return false
+        return 0
 
     // Remove the current ability.
     target.removeAbility(oldID)
@@ -199,7 +221,7 @@ function switchAbilities(unit target) returns bool
     target.makeAbilityPermanent(newID, true)
 
     // Indicate success.
-    return true
+    return newID
 
 function onDrop(unit caster)
     // Create the corpse that is dropped.
@@ -245,9 +267,21 @@ function updateCount(unit target, int differential)
     // Ensure that the ability is maintained during transformation.
     target.makeAbilityPermanent(track.run(after), true)
 
+    // Exit if no further operations are needed.
+    if after != 0 and after != MAX_COUNT
+        return
+
     // Switch abilities if the unit has reached the end of a track.
-    if after == 0 or after == MAX_COUNT
-        switchAbilities(target)
+    let newID = switchAbilities(target)
+
+    // Disable the new ability temporarily to prevent accidental rollback.
+    target.disableAbility(newID, true, false)
+    // target.getOwner().setAbilityAvailable(newID, false)
+
+    // Enable the new ability after a suitable interval.
+    doAfter(LOCKOUT) ->
+        // target.getOwner().setAbilityAvailable(newID, true)
+        target.disableAbility(newID, false, false)
 
 // TODO: Don't cancel orders for abilities that can actually have autocast.
 function onOrder(unit target, int orderID)
@@ -263,7 +297,7 @@ function onOrder(unit target, int orderID)
         return
 
     // Switch the abilities, as requested.
-    if switchAbilities(target)
+    if switchAbilities(target) != 0
         // Exit upon success, as disabling abilities includes undoing the order.
         return
 
@@ -308,6 +342,15 @@ function onDeath(unit target)
     for _ = 1 to count
         createCorpse(target.getPos())
 
+function onKey(player triggerer)
+    // Attempt to switch the ability for each unit selected.
+    forUnitsSelected(triggerer) (unit target) ->
+        print("Considering " + target.getName())
+        if triggerer.canControl(target) and target.canMoveCorpses()
+            print("switch abilities.")
+            switchAbilities(target)
+
+
 init
     registerPlayerUnitEvent(EVENT_PLAYER_UNIT_SUMMON) ->
         onGrab(EventData.getSummoningUnit(), EventData.getSummonedUnit())
@@ -325,3 +368,10 @@ init
 
     registerPlayerUnitEvent(EVENT_PLAYER_UNIT_DEATH) ->
         onDeath(EventData.getDyingUnit())
+
+    // Create the trigger to allow for psuedo-hotkey functionality.
+    let t = CreateTrigger()..addAction(-> onKey(GetTriggerPlayer()))
+
+    // Listen to the activity of every player.
+    for index = 0 to bj_MAX_PLAYER_SLOTS - 1
+        t.registerPlayerKeyPress(players[index], OSKEY_V, OSKEY_META.NONE, true)

--- a/wurst/objects/abilities/MoveCorpses.wurst
+++ b/wurst/objects/abilities/MoveCorpses.wurst
@@ -276,11 +276,9 @@ function updateCount(unit target, int differential)
 
     // Disable the new ability temporarily to prevent accidental rollback.
     target.disableAbility(newID, true, false)
-    // target.getOwner().setAbilityAvailable(newID, false)
 
     // Enable the new ability after a suitable interval.
     doAfter(LOCKOUT) ->
-        // target.getOwner().setAbilityAvailable(newID, true)
         target.disableAbility(newID, false, false)
 
 // TODO: Don't cancel orders for abilities that can actually have autocast.
@@ -346,6 +344,7 @@ function onKey(player triggerer)
     // Attempt to switch the ability for each unit selected.
     forUnitsSelected(triggerer) (unit target) ->
         print("Considering " + target.getName())
+        // Check that the action is both legal and valid.
         if triggerer.canControl(target) and target.canMoveCorpses()
             print("switch abilities.")
             switchAbilities(target)


### PR DESCRIPTION
$changelog: Added hotkey support for switching between grabbing and dropping corpses.
$changelog: Added lockout period when automatically switching between grabbing and dropping corpses.

This also addresses a bug with the `owner` toolkit command where the wrong argument was being parsed and adds toolkit commands for modifying alliance settings.