### PR TITLE
Added additional orders to the banlist.

### DIFF
--- a/wurst/lib/OrderStringFactory_config.wurst
+++ b/wurst/lib/OrderStringFactory_config.wurst
@@ -30,9 +30,19 @@ let banned = new HashSet<string>()..add(
     "lightningshield", // Booster - Lightning Shield
     "spiritlink",      // Booster - Spirit Link
     "roar",            // Booster - Battlecry
-    "autodispel"       // Priest - Cure All
+    "autodispel",      // Priest - Cure All
+    // See PR for explanation of commented code.
+    // "raisedeadon",     // Misc - Grab Corpse (Switch)
+    // "raisedeadoff",    // Misc - Grab Corpse (Undo Error)
+    // "replenish",       // Misc - Drop Corpse (Ability)
+    // "replenishon",     // Misc - Drop Corpse (Switch)
+    // "replenishoff",    // Misc - Drop Corpse (Undo Error)
+    // Does not appear to actually be used, but we err on the safe side.
+    // "raisedead",       // Misc - Grab Corpse (Ability)
+    "instant"          // Misc - Grab Corpse (Ability)
 )
 
 
 @config function isOrderBanned(string _order) returns boolean
+    print("considering " + _order)
     return banned.has(_order)

--- a/wurst/lib/Toolkit.wurst
+++ b/wurst/lib/Toolkit.wurst
@@ -25,7 +25,7 @@ public function registerToolkitCommand(string command, CommandHandler handler)
         if isEnabled
             handler.run(triggerPlayer, arguments)
 
-// This operation is deliberately irreversible.
+// Enables the toolkit irreversibly.
 public function enableToolkit()
     // Set the flag to enable all toolkit commands.
     isEnabled = true
@@ -33,3 +33,7 @@ public function enableToolkit()
     // Fire each registered callback for the event.
     for callback in callbacks
         callback.run()
+
+// Checks whether the toolkit has been enabled.
+public function isEnabled() returns boolean
+    return isEnabled

--- a/wurst/objects/abilities/TrollUpgradeSpell.wurst
+++ b/wurst/objects/abilities/TrollUpgradeSpell.wurst
@@ -43,7 +43,7 @@ public class TrollUpgradeSubSpell
         ..setIconNormal(icon)
         ..setIconResearch(icon)
         ..presetTooltipNormal(lvl -> toolTip)
-        ..presetTooltipNormalExtended(lvl -> toolTipExt)
+        ..presetTooltipNormalExtended(lvl -> toolTipExt + "|nRequires level {0}.".format(this.levelReq.toString()))
         ..presetFollowThroughTime(lvl -> 0)
         ..setCooldown(1, 0)
         ..setLevels(1)


### PR DESCRIPTION
$changelog: Fixed bug where corpses could not be grabbed for some classes.

For some reason, banning additional order IDs will cause the map to break. The order string factory currently only reaches `rainofchaos`, which comes before any of the other order IDs we would like to ban. Because of this, we can avoid banning them for now but it also means that banning them should have no effect.

Despite this, adding the commented code will cause the ability object output to still have all the same order IDs, but the button position for some channel abilities to be incorrect. These incorrect button positions all use `(0, 0)`, causing the map to crash.

This problem may go away if all order IDs use the factory. Some channel abilities current have their generated orders overridden by hard-coded values.