### PR TITLE
Corrected healing potion tooltip.

### DIFF
--- a/wurst/objects/items/Raw.wurst
+++ b/wurst/objects/items/Raw.wurst
@@ -1398,6 +1398,7 @@ import LocalObjectIDs
 	..setString("iico", "ReplaceableTextures\\CommandButtons\\BTNLesserRejuvPotion.blp")
 	..setString("icid", "A002")
 	..setString("ides", "Restores 65 HP")
+	..setString("utub", "Restores 65 Health points.")
 	..setInt("idrp", 1)
 	..setString("ifil", "Models\\PotionPurpleLesser.mdl")
 	..setInt("igol", 0)


### PR DESCRIPTION
It said "restore 150 mana" because it's based off mana potion and the extended tooltip wasn't modified.