### PR TITLE
Changed hotkey for switching between abilities for moving corpses.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
+# VS Code
+.vscode/*
+
 # Wurst
 /_build
 wurst.dependencies
-.vscode/settings.json
 /temp
 /backups
 

--- a/wurst/objects/abilities/MoveCorpses.wurst
+++ b/wurst/objects/abilities/MoveCorpses.wurst
@@ -143,7 +143,7 @@ let switches = new HashMap<int, int>()
             ..presetCastRange(lvl -> 128)
             ..presetTooltipNormal(lvl -> "|c00ffcc00C|r - Grab Corpse")
             ..presetTooltipNormalExtended(lvl -> "Grabs a nearby corpse and stores it for later use. Unattended corpses will rot after two minutes.|n" + "Current Capacity: {0} / {1}".color(GOLD_COLOR).format(index.toString(), MAX_COUNT.toString()))
-            ..presetTooltipTurnOff(lvl -> "Right-click or hotkey V to begin dropping corpses.".color(ENERGY_COLOR))
+            ..presetTooltipTurnOff(lvl -> "Right-click or CTRL + Z to begin dropping corpses.".color(ENERGY_COLOR))
 
 // Used to drop meat via a Replenish effect, configured to not affect any units.
 // This ability is used because it has autocast and does not require a target.
@@ -168,7 +168,7 @@ let switches = new HashMap<int, int>()
             ..setName("Drop Corpse")
             ..presetTooltipNormal(lvl -> "|c00ffcc00C|r - Drop Corpse")
             ..presetTooltipNormalExtended(lvl -> "Drops a carried corpse onto the ground.|n" + "Current Capacity: {0} / {1}".color(GOLD_COLOR).format(index.toString(), MAX_COUNT.toString()))
-            ..presetTooltipTurnOff(lvl -> "Right-click or hotkey V to begin grabbing corpses.".color(ENERGY_COLOR))
+            ..presetTooltipTurnOff(lvl -> "Right-click or CTRL + Z to begin grabbing corpses.".color(ENERGY_COLOR))
 
 
 // Checks whether the unit is able to move corpses.
@@ -377,4 +377,4 @@ init
 
     // Listen to the activity of every player.
     for index = 0 to bj_MAX_PLAYER_SLOTS - 1
-        t.registerPlayerKeyPress(players[index], OSKEY_V, OSKEY_META.NONE, true)
+        t.registerPlayerKeyPress(players[index], OSKEY_Z, OSKEY_META.CTRL, true)


### PR DESCRIPTION
$changelog: Changed hotkey for switching between abilities for moving corpses.

The previous hotkey V had two problems:

1. While no abilities used hotkey V innately, this conflicted with the hotkey for Sleep Outside when using the grid layout option built into Warcraft III as a whole.
2. The previous hotkey did not work when SHIFT was held down. Standard hotkeys have no such limitation, so this could confuse users. The addition of a metakey makes it clearer that the user must be precise.