### PR TITLE
Nerfed Living Clay.

### DIFF
--- a/wurst/__legacy__/crafting/Transmute.jurst
+++ b/wurst/__legacy__/crafting/Transmute.jurst
@@ -495,11 +495,6 @@ library Transmute initializer onInit requires LocalObjectIDs, UnitExtensions, It
                 set i[e] = GetItemTypeId(t[e])
                 set e = e +1
             endloop
-            if i[0] == ITEM_CLAY_BALL and i[1] == ITEM_MAGIC then
-                call RemoveItem(t[0])
-                call UnitAddItemByIdSwapped( ITEM_LIVING_CLAY, GetTriggerUnit() )
-                call lowerItem(1)
-            endif
             if i[0] == ITEM_ANABOLIC_POTION and i[1] == ITEM_MANA_CRYSTAL then
                 call RemoveItem(t[0])
                 call RemoveItem(t[1])
@@ -623,6 +618,11 @@ library Transmute initializer onInit requires LocalObjectIDs, UnitExtensions, It
                 call RemoveItem(t[1])
                 call UnitAddItemByIdSwapped( ITEM_BLOW_GUN, GetTriggerUnit() )
                 call lowerItem(2)
+            endif
+            if i[0] == ITEM_CLAY_BALL and i[1] == ITEM_MANA_CRYSTAL then
+                call RemoveItem(t[0])
+                call UnitAddItemByIdSwapped( ITEM_LIVING_CLAY, GetTriggerUnit() )
+                call lowerItem(1)
             endif
             if i[0] == ITEM_NETS and i[1] == ITEM_STONE
                 if GetItemCharges(t[0]) > 1 then

--- a/wurst/assets/LocalAssets.wurst
+++ b/wurst/assets/LocalAssets.wurst
@@ -26,9 +26,6 @@ public class LocalIcons
     static constant bTNPoisonSpear      = "ReplaceableTextures\\CommandButtons\\BTNPoisonSpear.blp"
     static constant bTNUltraPoisonSpear = "ReplaceableTextures\\CommandButtons\\BTNUltraPoisonSpear.blp"
 
-public class ItemIds
-    static constant sentryWards = 'wswd'
-
 public class LocalUnits
     // A nonexistent model used to hide units.
     static constant dummy = "Dummy.mdl"
@@ -51,26 +48,6 @@ public class LocalItems
     static constant mageMasher         = "Models\\MageMasher.mdl"
     static constant manaCrystal        = "Models\\ManaStone.mdx"
     static constant magic              = "Models\\MoonStone.mdx"
-
-public class UnitShadow
-    static constant none        = ""
-    static constant shadow      = "Shadow"
-    static constant shadowFlyer = "ShadowFlyer"
-
-public class UnitClasses
-    static constant ancient    = "ancient"
-    static constant giant      = "giant"
-    static constant mechanical = "mechanical"
-    static constant neutral    = "neutral"
-    static constant suicidal   = "sapper"
-    static constant summoned   = "summoned"
-    static constant tauren     = "tauren"
-    static constant townHall   = "townhall"
-    static constant tree       = "tree"
-    static constant undead     = "undead"
-    static constant walkable   = "standon"
-    static constant ward       = "ward"
-    static constant worker     = "peon"
 
 public class LocalAbilityIds
     static constant corpseConsume     = compiletime(ABIL_ID_GEN.next())
@@ -99,9 +76,36 @@ public class LocalUnitIds
     static constant dummyMeatGather = compiletime(UNIT_ID_GEN.next())
     static constant theOneHut       = compiletime(UNIT_ID_GEN.next())
 
+// TODO: Move this to standard library.
+
+public class BuffIds
+    static constant thornsAura = 'BEah'
+
+public class DestructibleIds
+    static constant ruinedGateDiagonal2 = 'ZTg4'
+
+public class ItemIds
+    static constant sentryWards = 'wswd'
+
 public class PathingTextures
     static constant simpleSolid4x4 = "PathTextures\\4x4SimpleSolid.tga"
 
-// TODO: Move this to standard library.
-public class DestructibleIds
-    static constant ruinedGateDiagonal2 = 'ZTg4'
+public class UnitShadow
+    static constant none        = ""
+    static constant shadow      = "Shadow"
+    static constant shadowFlyer = "ShadowFlyer"
+
+public class UnitClasses
+    static constant ancient    = "ancient"
+    static constant giant      = "giant"
+    static constant mechanical = "mechanical"
+    static constant neutral    = "neutral"
+    static constant suicidal   = "sapper"
+    static constant summoned   = "summoned"
+    static constant tauren     = "tauren"
+    static constant townHall   = "townhall"
+    static constant tree       = "tree"
+    static constant undead     = "undead"
+    static constant walkable   = "standon"
+    static constant ward       = "ward"
+    static constant worker     = "peon"

--- a/wurst/lib/OrderStringFactory_config.wurst
+++ b/wurst/lib/OrderStringFactory_config.wurst
@@ -31,7 +31,7 @@ let banned = new HashSet<string>()..add(
     "spiritlink",      // Booster - Spirit Link
     "roar",            // Booster - Battlecry
     "autodispel",      // Priest - Cure All
-    "berserk",          // Misc - Panic
+    "berserk",         // Misc - Panic
     // See PR for explanation of commented code.
     // "raisedeadon",     // Misc - Grab Corpse (Switch)
     // "raisedeadoff",    // Misc - Grab Corpse (Undo Error)

--- a/wurst/objects/abilities/scout/Reveal.wurst
+++ b/wurst/objects/abilities/scout/Reveal.wurst
@@ -31,54 +31,25 @@ let TOOLTIP_EXTENDED_GREATER = "Reveals an large area around you, detects invisi
 
 @compiletime function revealDefinition()
     new AbilityDefinitionFarseerFarSight(ABILITY_ID_REVEAL_DUMMY)
-    ..setDummyAbility()
-    ..setLevels(3)
-    ..presetAreaofEffect(lvl -> 300. + lvl * AOE)
-    ..presetDurationHero(lvl -> DURATION)
-    ..presetDurationNormal(lvl -> DURATION)
+        ..setDummyAbility()
+        ..setLevels(3)
+        ..presetAreaofEffect(lvl -> 300. + lvl * AOE)
+        ..presetDurationHero(lvl -> DURATION)
+        ..presetDurationNormal(lvl -> DURATION)
 
     new AbilityDefinitionFarseerFarSight(ABILITY_ID_GREATER_REVEAL_DUMMY)
-    ..setDummyAbility()
-    ..setLevels(1)
-    ..setAreaofEffect(1, GREATER_AOE)
-    ..presetDurationHero(lvl -> GREATER_DURATION)
-    ..presetDurationNormal(lvl -> GREATER_DURATION)
+        ..setDummyAbility()
+        ..setLevels(1)
+        ..setAreaofEffect(1, GREATER_AOE)
+        ..presetDurationHero(lvl -> GREATER_DURATION)
+        ..presetDurationNormal(lvl -> GREATER_DURATION)
 
     new AbilityDefinitionFarseerFarSight(ABILITY_ID_RECON_REVEAL_DUMMY)
-    ..setDummyAbility()
-    ..setLevels(3)
-    ..presetAreaofEffect(lvl -> 400. + (lvl * 600.))
-    ..presetDurationHero(lvl -> DURATION)
-    ..presetDurationNormal(lvl -> DURATION)
-
-
-
-
-// class DummyReveal extends AbilityDefinitionFarseerFarSight
-//     construct(int newAbilityId)
-//         super(newAbilityId)
-//         this.setLevels(3)
-//         this.presetCastRange(lvl -> 99999)
-//         this.presetAreaofEffect(lvl -> 300. + lvl * AOE)
-//         this.presetDurationHero(lvl -> DURATION)
-//         this.presetDurationNormal(lvl -> DURATION)
-//         this.presetCooldown(lvl -> 0)
-
-// class DummyGreaterReveal extends DummyReveal
-//     construct(int newAbilityId)
-//         super(newAbilityId)
-//         this.setLevels(1)
-//         this.setAreaofEffect(1, GREATER_AOE)
-//         this.presetDurationHero(lvl -> GREATER_DURATION)
-//         this.presetDurationNormal(lvl -> GREATER_DURATION)
-
-// class DummyReconReveal extends DummyReveal
-//     construct(int newAbilityId)
-//         super(newAbilityId)
-//         this.setLevels(3)
-//         this.presetAreaofEffect(lvl -> 400. + (lvl * 600.))
-//         this.presetDurationHero(lvl -> DURATION)
-//         this.presetDurationNormal(lvl -> DURATION)
+        ..setDummyAbility()
+        ..setLevels(3)
+        ..presetAreaofEffect(lvl -> 400. + (lvl * 600.))
+        ..presetDurationHero(lvl -> DURATION)
+        ..presetDurationNormal(lvl -> DURATION)
 
 
 class Reveal extends ChannelAbilityPreset
@@ -128,43 +99,37 @@ class ChainReveal extends Reveal
     new Reveal(ABILITY_REVEAL_ID, "E", new Pair(1, 1))
     new GreaterReveal(ABILITY_GREATER_REVEAL_ID, "E", new Pair(1, 1))
     new ChainReveal(ABILITY_CHAIN_REVEAL, "E", new Pair(1, 1))
-    //new DummyReveal(ABILITY_ID_REVEAL_DUMMY)
-    //new DummyGreaterReveal(ABILITY_ID_GREATER_REVEAL_DUMMY)
-    //new DummyReconReveal(ABILITY_ID_RECON_REVEAL_DUMMY)
 
 function onCastReveal()
     let caster = GetSpellAbilityUnit()
     let owner = caster.getOwner()
     let spellId = GetSpellAbilityId()
     let lvl = caster.getAbilityLevel(spellId)
-    var dummyToCast = ABILITY_ID_REVEAL_DUMMY
 
-    if spellId == ABILITY_GREATER_REVEAL_ID
-        dummyToCast = ABILITY_ID_GREATER_REVEAL_DUMMY
+    // Determine the Far Sight ability based on the original ability.
+    let dummyToCast = spellId == ABILITY_GREATER_REVEAL_ID
+        ? ABILITY_ID_GREATER_REVEAL_DUMMY
+        : ABILITY_ID_REVEAL_DUMMY
 
-    if InstantDummyCaster.castPoint(owner, dummyToCast, lvl, Orders.farsight, caster.getPos()) == false
+    print("casting  {0} at level {1}.".format(dummyToCast.toRawCode(), lvl.toString()))
+
+    // Cast the Far Sight ability centered on the original caster.
+    if not InstantDummyCaster.castPoint(owner, dummyToCast, lvl, Orders.farsight, caster.getPos())
         error("Reveal cast failed, this isn't supposed to happen, report this please.")
-    // new DummyCaster()
-    //     ..owner(owner)
-    //     ..origin(caster.getPos() + vec2(100,0))
-    //     ..castPoint(dummyToCast, lvl, Orders.farsight, caster.getPos())
-
 
 init
-    registerSpellEffectEvent(ABILITY_REVEAL_ID, () -> onCastReveal())
-    registerSpellEffectEvent(ABILITY_GREATER_REVEAL_ID, () -> onCastReveal())
+    registerSpellEffectEvent(ABILITY_REVEAL_ID, function onCastReveal)
+    registerSpellEffectEvent(ABILITY_GREATER_REVEAL_ID, function onCastReveal)
+
     EventListener.onCast(ABILITY_CHAIN_REVEAL) (unit caster) ->
         let owner = caster.getOwner()
         let lvl = caster.getAbilityLevel(ABILITY_CHAIN_REVEAL)
-        // Reveal on living clay
+
+        // Reveal nearby living clay.
         forUnitsOfPlayer(owner) u ->
             if u.getTypeId() == UNIT_LIVING_CLAY
                 if InstantDummyCaster.castPoint(owner, ABILITY_ID_RECON_REVEAL_DUMMY, lvl, Orders.farsight, u.getPos()) == false
                     error("Reveal cast failed, this isn't supposed to happen, report this please.")
-                // new DummyCaster()
-                //     ..owner(owner)
-                //     ..origin(u.getPos() + vec2(100,0))
-                //     ..castPoint(ABILITY_ID_RECON_REVEAL_DUMMY, lvl, Orders.farsight, u.getPos())
 
         // Get nearby enemy units
         let unitsAround = CreateGroup()..enumUnitsInRange(caster.getPos(), 2700)
@@ -178,9 +143,5 @@ init
             if randomUnit != null
                 if InstantDummyCaster.castTarget(owner, ABILITY_ID_GREATER_REVEAL_DUMMY, lvl, Orders.farsight, randomUnit) == false
                     error("Reveal cast failed, this isn't supposed to happen, report this please.")
-                // new DummyCaster()
-                //     ..owner(owner)
-                //     ..origin(randomUnit.getPos() + vec2(100,0))
-                //     ..castTarget(ABILITY_ID_GREATER_REVEAL_DUMMY, lvl, Orders.farsight, randomUnit)
                 unitsAround.removeUnit(randomUnit)
         unitsAround.destr()

--- a/wurst/objects/abilities/scout/Reveal.wurst
+++ b/wurst/objects/abilities/scout/Reveal.wurst
@@ -9,7 +9,6 @@ import Lodash
 import InstantDummyCaster
 import ClosureForGroups
 import ErrorHandling
-import ObjectIDManager
 
 let ABILITY_ID_REVEAL_DUMMY = compiletime(ABIL_ID_GEN.next())
 let ABILITY_ID_RECON_REVEAL_DUMMY = compiletime(ABIL_ID_GEN.next())

--- a/wurst/objects/abilities/scout/Reveal.wurst
+++ b/wurst/objects/abilities/scout/Reveal.wurst
@@ -9,6 +9,7 @@ import Lodash
 import InstantDummyCaster
 import ClosureForGroups
 import ErrorHandling
+import ObjectIDManager
 
 let ABILITY_ID_REVEAL_DUMMY = compiletime(ABIL_ID_GEN.next())
 let ABILITY_ID_RECON_REVEAL_DUMMY = compiletime(ABIL_ID_GEN.next())
@@ -111,8 +112,6 @@ function onCastReveal()
         ? ABILITY_ID_GREATER_REVEAL_DUMMY
         : ABILITY_ID_REVEAL_DUMMY
 
-    print("casting  {0} at level {1}.".format(dummyToCast.toRawCode(), lvl.toString()))
-
     // Cast the Far Sight ability centered on the original caster.
     if not InstantDummyCaster.castPoint(owner, dummyToCast, lvl, Orders.farsight, caster.getPos())
         error("Reveal cast failed, this isn't supposed to happen, report this please.")
@@ -131,13 +130,13 @@ init
                 if InstantDummyCaster.castPoint(owner, ABILITY_ID_RECON_REVEAL_DUMMY, lvl, Orders.farsight, u.getPos()) == false
                     error("Reveal cast failed, this isn't supposed to happen, report this please.")
 
-        // Get nearby enemy units
+        // Get nearby enemies.
         let unitsAround = CreateGroup()..enumUnitsInRange(caster.getPos(), 2700)
         unitsAround.forEachIn() elem ->
             if elem.getOwner().isAllyOf(owner)
                 unitsAround.removeUnit(elem)
 
-        // cast greater reveal on a random nearby unit
+        // Cast greater reveal on a random nearby unit.
         for i = 0 to lvl
             let randomUnit = unitsAround.getRandomUnit()
             if randomUnit != null

--- a/wurst/objects/items/LivingClay.wurst
+++ b/wurst/objects/items/LivingClay.wurst
@@ -130,12 +130,11 @@ let dummies = new HashMap<unit, unit>()
         ..setNumberofCharges(3)
         ..setCooldownGroup(PLACE_ABIL_ID.toRawCode())
         ..setDroppedWhenCarrierDies(true)
-        ..setGoldCost(0)
-        ..setLumberCost(8)
         ..setName("Living Clay")
         ..setTooltipBasic("Purchase Living Clay")
         ..setTooltipExtended(ITEM_TOOLTIP)
         ..setScalingValue(0.5)
+        ..setCanBeSoldToMerchants(false)
 
 // Pairs each ward with a dummy to impart the aura.
 function onWardEnter(unit target)

--- a/wurst/objects/items/LivingClay.wurst
+++ b/wurst/objects/items/LivingClay.wurst
@@ -3,24 +3,66 @@ package LivingClay
 // Standard library imports:
 import AbilityObjEditing
 import Assets
+import BuffObjEditing
 import EventHelper
+import HashMap
 import ItemObjEditing
 import ObjectIdGenerator
 import ObjectIds
+import OnUnitEnterLeave
 import RegisterEvents
+import SimError
+
+// Third-party imports:
+import StackNSplit
 
 // Local imports:
+import DummyUnits
 import LocalObjectIDs
 import LocalAssets
 
+// The configuration for the mechanism preventing clustering wards.
 @configurable let CLAY_WARD_LIMIT_RANGE = 500.0
 @configurable let CLAY_WARD_LIMIT_MAX_WARDS = 10
 
+// The sight radius of the ward, required to be the same throughout the day.
+@configurable let SIGHT_RADIUS = 700
+
+// The ID for the dummy unit that has the aura.
+let DUMMY_UNIT_ID = compiletime(UNIT_ID_GEN.next())
+
+// The ID for the ability for placing a ward.
 let PLACE_ABIL_ID = compiletime(ABIL_ID_GEN.next())
 
-let TOOLTIP = "" +
+// The ID for the ability for the aura around a ward.
+let AURA_ABIL_ID = compiletime(ABIL_ID_GEN.next())
+
+// The ID for the ability for the bestowed by the aura.
+let AURA_BUFF_ID = compiletime(ABIL_ID_GEN.next())
+
+let ITEM_TOOLTIP = "" +
     "Places a sentry ward to watch the nearby area. Lasts indefinitely until " +
     "approached, at which point it explodes and damages nearby enemies."
+
+let BUFF_TOOLTIP = "" +
+    "This unit senses that it is being watched by a nearby ward."
+
+// The mapping from ward to corresponding dummy units.
+let dummies = new HashMap<unit, unit>()
+
+// Creates a dummy unit that is used to impart the aura for a ward, which the
+// ward cannot do itself because invisible units cannot bestow auras on enemies.
+@compiletime function createDummyAuraUnit()
+    new UnitDefinition(DUMMY_UNIT_ID, UnitIds.locust)
+        ..addDummyProperties()
+        ..setNormalAbilities(
+            commaList(
+                // Keep the existing locust ability.
+                AbilityIds.locust,
+                // Make the unit notify enemies of its presence.
+                AURA_ABIL_ID
+            )
+        )
 
 @compiletime function createLivingClayDamageAbility()
     new AbilityDefinitionDeathDamageAOEmine(ABILITY_WARD_DESTROY)
@@ -29,27 +71,56 @@ let TOOLTIP = "" +
         ..presetPartialDamageRadius(lvl -> 400)
         ..presetPartialDamageAmount(lvl -> 5.)
 
+@compiletime function createLivingClayAuraBuff()
+    new BuffDefinition(AURA_BUFF_ID, BuffIds.thornsAura)
+        ..setIcon(LocalIcons.bTNGreenSentryWard)
+        ..setTooltipNormal(1, "Paranoia")
+        ..setTooltipNormalExtended(1, BUFF_TOOLTIP)
+
+@compiletime function createLivingClayAuraAbility()
+    new AbilityDefinitionKeeperoftheGroveThornsAura(AURA_ABIL_ID)
+        // Use the dummy buff.
+        ..presetBuffs(lvl -> commaList(
+            AURA_BUFF_ID
+        ))
+        // Prevent the level of the ability showing in the buff tooltip.
+        ..setHeroAbility(false)
+        ..setLevels(1)
+        // Prevent the aura from having a mechanical effect.
+        ..presetDamageDealttoAttackers(lvl -> 0)
+        ..presetDamageisPercentReceived(lvl -> false)
+        // Match the sight radius for the ward.
+        ..presetAreaofEffect(lvl -> SIGHT_RADIUS.toReal())
+        // Target enemies and exclude structures.
+        ..presetTargetsAllowed(lvl -> commaList(
+            TargetsAllowed.air,
+            TargetsAllowed.ground,
+            TargetsAllowed.enemies,
+            TargetsAllowed.vulnerable,
+            TargetsAllowed.invulnerable,
+            TargetsAllowed.hero
+        ))
+
 @compiletime function createLivingClayUnit()
     new UnitDefinition(UNIT_LIVING_CLAY, UnitIds.goblinlandmine)
         ..setNormalAbilities(commaList(
-            // Makes the unit invisible and ignored for pathing.
+            // Make the unit ignored for pathing.
             AbilityIds.ghostVisible,
-            // Makes the unit deal damage on death.
+            // Make the unit deal damage on death.
             ABILITY_WARD_DESTROY,
-            // Makes the unit die when approached.
+            // Make the unit die when approached.
             AbilityIds.mineexploding
         ))
         ..setIconGameInterface(LocalIcons.bTNGreenSentryWard)
         ..setArmorType(ArmorType.Small)
         ..setModelFile(Units.sentryWard)
         ..setName("Living Clay")
-        ..setSightRadiusNight(700)
-        ..setSightRadiusDay(1400)
+        ..setSightRadiusNight(SIGHT_RADIUS)
+        ..setSightRadiusDay(SIGHT_RADIUS)
 
 @compiletime function createLivingClaySummonAbility()
     new AbilityDefinitionItemPlaceMine(PLACE_ABIL_ID)
         ..presetUnitType(lvl -> UNIT_LIVING_CLAY.toRawCode())
-
 
 @compiletime function createLivingClayItem()
     new ItemDefinition(ITEM_LIVING_CLAY, ItemIds.sentryWards)
@@ -63,10 +134,40 @@ let TOOLTIP = "" +
         ..setLumberCost(8)
         ..setName("Living Clay")
         ..setTooltipBasic("Purchase Living Clay")
-        ..setTooltipExtended(TOOLTIP)
+        ..setTooltipExtended(ITEM_TOOLTIP)
         ..setScalingValue(0.5)
 
-function onCreate(unit target)
+// Pairs each ward with a dummy to impart the aura.
+function onWardEnter(unit target)
+    // Ignore units other than wards.
+    if target.getTypeId() != UNIT_LIVING_CLAY
+        return
+
+    // Create the dummy for the aura effect.
+    let dummy = createUnit(
+        target.getOwner(),
+        DUMMY_UNIT_ID,
+        target.getPos(),
+        target.getFacingAngle()
+    )
+
+    // Store the relation so that the dummy may be removed later.
+    dummies.put(target, dummy)
+
+// Removes the paired dummy with a ward exits the map.
+function onWardLeave(unit target)
+    // Ignore units other than wards.
+    if target.getTypeId() != UNIT_LIVING_CLAY
+        return
+
+    // Look up the dummy for the ward.
+    let dummy = dummies.getAndRemove(target)
+
+    // Remove the dummy upon the ward exiting.
+    dummy.remove()
+
+// Enforces a limit on the maximum amount of wards in a cluster.
+function onWardPlace(unit caster, unit target)
     // Exit the unit created is not a ward.
     if target.getTypeId() != UNIT_LIVING_CLAY
         return
@@ -78,15 +179,29 @@ function onCreate(unit target)
         Filter(-> GetFilterUnit().getTypeId() == UNIT_LIVING_CLAY)
     )
 
-    // Undo the placement.
-    if ENUM_GROUP.size() > CLAY_WARD_LIMIT_MAX_WARDS
-        // Create a replacement ward.
-        createItem(ITEM_LIVING_CLAY, target.getPos())
-            ..setCharges(1)
+    // Exit if the unit is allowed to be summoned at its current location.
+    if ENUM_GROUP.size() <= CLAY_WARD_LIMIT_MAX_WARDS
+        return
 
-        // Removed the placed ward without exploding it.
-        target.remove()
+    // Undo the placement by removing the new ward without exploding it.
+    target.remove()
+
+    // Create a replacement ward.
+    let replacement = createItem(ITEM_LIVING_CLAY, target.getPos())
+        ..setCharges(1)
+
+    // Return the replacement to the unit responsible for the placement.
+    caster.stackItem(replacement)
+
+    // Notify the user of this operation.
+    simError(target.getOwner(), "Cannot place more wards here.")
 
 init
     registerPlayerUnitEvent(EVENT_PLAYER_UNIT_SUMMON) ->
-        onCreate(EventData.getSummonedUnit())
+        onWardPlace(EventData.getSummoningUnit(), EventData.getSummonedUnit())
+
+    onEnter() ->
+        onWardEnter(getEnterLeaveUnit())
+
+    onLeave() ->
+        onWardLeave(getEnterLeaveUnit())

--- a/wurst/objects/units/DummyUnits.wurst
+++ b/wurst/objects/units/DummyUnits.wurst
@@ -1,0 +1,24 @@
+package DummyUnits
+
+// Standard library imports:
+import Assets
+import ObjectIds
+import UnitObjEditing
+
+// Local imports:
+import LocalAssets
+
+// Causes a unit definition to not appear or have any visible side-effects.
+public function UnitDefinition.addDummyProperties()
+    this
+        // Block effects from selecting, targeting, and enumerating the unit.
+        // Disable the minimap indicator for the unit.
+        ..setNormalAbilities(commaList(AbilityIds.locust))
+        // Disable the model, which also blocks selecting and targeting.
+        ..setModelFile(LocalUnits.dummy)
+        // Remove the shadow so the unit has no visual impact.
+        ..setShadowImageUnit(UnitShadow.none)
+        // Prevent collision, including when placed directly on another unit.
+        ..setMovementType(MovementType.Fly)
+        // Prevents behavior where stacked flying units will later disperse.
+        ..setSpeedBase(0)

--- a/wurst/objects/units/Merchants.wurst
+++ b/wurst/objects/units/Merchants.wurst
@@ -6,6 +6,7 @@ import ObjectIds
 import UnitObjEditing
 
 // Local imports:
+import DummyUnits
 import LocalObjectIDs
 import LocalAssets
 
@@ -41,6 +42,9 @@ function createMerchantShip(int newId) returns UnitDefinition
 
 @compiletime function createDummyGoldMineShip()
     createMerchantShip(LocalUnitIds.dummyGoldMine)
+        // Negate mechanical effects for the unit.
+        ..addDummyProperties()
+        // Override the locust ability and show the minimap gold mine indicator.
         ..setNormalAbilities(
             commaList(
                 AbilityIds.goldMineability,
@@ -49,13 +53,6 @@ function createMerchantShip(int newId) returns UnitDefinition
         )
         // Allow the gold mine icon to appear.
         ..setHideMinimapDisplay(false)
-        // Disable the model, which blocks selecting and targeting.
-        ..setModelFile(LocalUnits.dummy)
-        // Remove the shadow so the unit has no visual impact.
-        ..setShadowImageUnit(UnitShadow.none)
-        // Prevent collision with placed directly on another unit.
-        ..setMovementType(MovementType.Fly)
-        ..setSpeedBase(0)
 
 @compiletime function createMerchantShip1()
     createMerchantShip(UNIT_TRADE_SHIP_1)

--- a/wurst/systems/commands/SpawningTestHelpers.wurst
+++ b/wurst/systems/commands/SpawningTestHelpers.wurst
@@ -100,7 +100,7 @@ init
         if id <= 0
             print(CREATE_HELP_MESSAGE)
         else
-            let owner = args.size() > 3 ? players[args.get(3).toInt() - 1] : triggerPlayer
+            let owner = args.size() > 3 ? players[args.get(3).toInt()] : triggerPlayer
             let troll = triggerPlayer.getTroll()
             let pos = troll.getPos().polarOffset(troll.getFacingAngle(), 100)
 

--- a/wurst/systems/crafting/QuickMakeSpell.wurst
+++ b/wurst/systems/crafting/QuickMakeSpell.wurst
@@ -76,7 +76,6 @@ constant WDH_SPELLBOOK = commaList(
     ABILITY_QM_SCROLL_FIREBALL,
     ABILITY_QM_SCROLL_CYCLONE,
     ABILITY_QM_SCROLL_SWIFTNESS,
-    ABILITY_QM_LIVING_CLAY,
     ABILITY_QM_MAGIC_SEED,
     ABILITY_QM_SPIRIT_WARD
 )
@@ -257,7 +256,6 @@ function getQuickMakeSpells() returns LinkedList<QuickMakeSpell>
         new QuickMakeSpell("Cloak Of Mana"             , TRANSMUTE_TOOLTIP+CLOAK_MANA_RECIPE         , "CloakOfMana"               , ABILITY_QM_CLOAK_MANA         , 3, 1, "F", QM_TOOLIP),
 
         // Second Page
-        new QuickMakeSpell("Living Clay"               , TRANSMUTE_TOOLTIP+LIVING_CLAY_RECIPE        , "GreenSentryWard"           , ABILITY_QM_LIVING_CLAY        , 2, 2, "R", QM_TOOLIP),
         new QuickMakeSpell("Magic Seed"                , TRANSMUTE_TOOLTIP+MAGIC_SEED_RECIPE         , "Root"                      , ABILITY_QM_MAGIC_SEED         , 2, 2, "A", QM_TOOLIP),
         new QuickMakeSpell("Spirit Ward"               , TRANSMUTE_TOOLTIP+SPIRIT_WARD_RECIPE        , "AbsorbMagic"               , ABILITY_QM_SPIRIT_WARD        , 2, 2, "S", QM_TOOLIP),
         new QuickMakeSpell("Poison"                    , TRANSMUTE_TOOLTIP+POISON_RECIPE             , "HealingSalve"              , ABILITY_QM_POISON             , 0, 2, "Z", QM_TOOLIP),
@@ -274,6 +272,7 @@ function getQuickMakeSpells() returns LinkedList<QuickMakeSpell>
         new QuickMakeSpell("Ultra Poison Spear"   , TRANSMUTE_TOOLTIP+ULTRA_POISON_SPEAR_RECIPE   , "UltraPoisonSpear"       , ABILITY_QM_ULTRA_POISON_SPEAR   , 2, 1, "D", QM_TOOLIP),
         new QuickMakeSpell("Nets"                 , TRANSMUTE_TOOLTIP+NETS_RECIPE                 , "Ensnare"                , ABILITY_QM_NETS                 , 0, 2, "Z", QM_TOOLIP),
         new QuickMakeSpell("Hunting Net"          , TRANSMUTE_TOOLTIP+HUNTING_NET_RECIPE          , "HuntingNet"             , ABILITY_QM_HUNTING_NET          , 1, 2, "X", QM_TOOLIP),
+        new QuickMakeSpell("Living Clay"          , TRANSMUTE_TOOLTIP+LIVING_CLAY_RECIPE          , "GreenSentryWard"        , ABILITY_QM_LIVING_CLAY          , 3, 1, "F", QM_TOOLIP),
 
         // Second Page
         new QuickMakeSpell("Smoke Bomb"           , TRANSMUTE_TOOLTIP+SMOKE_BOMB_RECIPE           , "SmokePot"               , ABILITY_QM_SMOKE_BOMB           , 0, 0, "Q", QM_TOOLIP),

--- a/wurst/systems/crafting/QuickMakeToolTips.wurst
+++ b/wurst/systems/crafting/QuickMakeToolTips.wurst
@@ -179,7 +179,6 @@ public let SCROLL_LIVING_DEAD_RECIPE    = "a Living Dead Spell Scroll. Can summo
 public let SCROLL_TSUNAMI_RECIPE        = "a Tsunami Spell Scroll. Can cast a tsunami, dealing 25 damage. Good for destroying base defenses."+makeToolTipCooldown(25)+"\n\n1x "+WATER+" + 1x "+MC
 public let SCROLL_SWIFTNESS_RECIPE      = "a Swiftness Spell Scroll. Can increase movement speed of surrounding allies to maximum."+makeToolTipDuration(7, 7, 35)+"\n\n1x "+ANABOLIC+" + 1x "+MC
 
-public let LIVING_CLAY_RECIPE           = "a Living Clay. A seeing ward that explode on contact, has 3 charges :\n\n1x "+CLAY_BALL+" + 1x "+MAGIC
 public let MAGIC_SEED_RECIPE            = "a Magic Seed. Can grow a tree, has 2 charges :\n\n1x "+STICK+" + 1x "+MC
 public let SPIRIT_WARD_RECIPE           = "a Spirit Ward. Can be used to revive 1 allied troll :\n\n3x "+MC+" + 1x "+STICK
 public let POISON_RECIPE                = "a Poison salve. Can be used to craft poison spear :\n\n3x "+MUSHROOM
@@ -195,6 +194,7 @@ public let CLOAK_MANA_RECIPE            = "a Cloak Of Mana. Can restore "+MANA_A
 // Workshop
 
 public let ENSNARE_TRAP_RECIPE = "an Ensnare Trap. Deals few ranged damage, can net trolls & animals, good for killing hawk :\n\n1x "               +TINDER     +" + 1x "+BONE +" + 1x "+STICK
+public let LIVING_CLAY_RECIPE           = "a Living Clay. A sentry ward that explodes on contact, has 3 charges :\n\n1x "+CLAY_BALL+" + 1x "+MC
 
 public let MANA_CRYSTAL_RECIPE = "A glowing crystal of mana. Used to make magical items :\n\n1x "    +WIND    +" + 1x "+WATER
 

--- a/wurst/systems/crafting/WitchDoctorHutQuickMake.wurst
+++ b/wurst/systems/crafting/WitchDoctorHutQuickMake.wurst
@@ -61,10 +61,6 @@ init
     ..add(ITEM_POISON)
     ..add(ITEM_POISON)
 
-    new QuickMake(ABILITY_QM_LIVING_CLAY)
-    ..add(ITEM_CLAY_BALL)
-    ..add(ITEM_MAGIC)
-
     new QuickMake(ABILITY_QM_MAGIC_SEED)
     ..add(ITEM_STICK)
     ..add(ITEM_MANA_CRYSTAL)

--- a/wurst/systems/crafting/WorkshopQuickMake.wurst
+++ b/wurst/systems/crafting/WorkshopQuickMake.wurst
@@ -65,3 +65,7 @@ init
     new QuickMake(ABILITY_QM_HUNTING_NET)
     ..add(ITEM_NETS)
     ..add(ITEM_STONE)
+
+    new QuickMake(ABILITY_QM_LIVING_CLAY)
+    ..add(ITEM_CLAY_BALL)
+    ..add(ITEM_MANA_CRYSTAL)

--- a/wurst/systems/entities/buildings/Workshop.wurst
+++ b/wurst/systems/entities/buildings/Workshop.wurst
@@ -16,6 +16,7 @@ public class Workshop extends Building
     override function postCreate()
         super.postCreate()
 
+        getUnit().addAbility(ABILITY_QM_LIVING_CLAY)
         getUnit().addAbility(ABILITY_QM_HUNTING_NET)
         getUnit().addAbility(ABILITY_QM_DARK_THISTLES)
         getUnit().addAbility(ABILITY_QM_ENSNARE_TRAP)

--- a/wurst/systems/spawns/BushSpawns.wurst
+++ b/wurst/systems/spawns/BushSpawns.wurst
@@ -47,12 +47,16 @@ class BushPool
         return pool.placeRandomItem(pos)
 
 function addItemToBush(unit target)
+    // Ignore units that have been modified and are no longer viable.
+    if target == null or not target.isAlive()
+        return
+
     // Randomly choose the item being created.
     let choice = BushPool
         .findForUnitId(target.getTypeId())
         .getItem(target.getPos())
 
-    // Allow for the itempool to miss.
+    // Allow the itempool to miss.
     if target != null
         // Check that the target has room for the item.
         if not target.addOrStackItem(choice)
@@ -118,3 +122,8 @@ init
     new BushPool(UNIT_WATER_HERB_BUSH, 'd108')
         ..addItem(ITEM_RIVER_ROOT, 1)
         ..addItem(ITEM_RIVER_STEM, 1)
+
+    // Remove all Scout Bushes, as per #502, pending playtesting.
+    // TODO: Properly remove the indicator units once playtesting is complete.
+    registerCallback(UNIT_SCOUTS_BUSH) (unit target) ->
+        target.remove()


### PR DESCRIPTION
$changelog: Reduced daytime sight radius of Living Clay to the nighttime value.
$changelog: Removed Scout Bush from the game.
$changelog: Added aura that will indicate when units are being watched by a ward. 
$changelog: Removed sell price for Living Clay.
$changelog: Moved Living Clay recipe to the Workshop.
$changelog: Changed Living Clay recipe to use Magic instead of Mana Crystal.