### PR TITLE
Revert "Updated channel abilities to use generated orders. (#494)"

### DIFF
--- a/wurst/objects/abilities/gatherer/Radars.wurst
+++ b/wurst/objects/abilities/gatherer/Radars.wurst
@@ -72,7 +72,7 @@ class Radar
     string orderId = "channel"
     string icon = "ReplaceableTextures\\CommandButtons\\BTN{0}.blp"
 
-    construct(int id, string itemName, string toolTipExt, string icon, string hotkey, int buttonPosX, int buttonPosY)
+    construct(int id, string itemName, string toolTipExt, string icon, string hotkey, int buttonPosX, int buttonPosY, string orderId)
         this.id = id
         this.hotkey   = hotkey
         this.name     += itemName
@@ -80,6 +80,7 @@ class Radar
         this.buttonPosX  = buttonPosX
         this.buttonPosY  = buttonPosY
         this.toolTip  = makeToolTipNorm(hotkey, this.name)
+        this.orderId = orderId
         this.icon = this.icon.format(icon)
 
     function buildRadarSpell()
@@ -104,6 +105,7 @@ class Radar
         ..presetCooldown(lvl -> COOLDOWN)
         ..presetManaCost(lvl -> MANACOST)
         ..presetFollowThroughTime(lvl -> CASTTIME)
+        ..presetBaseOrderID(lvl -> orderId)
 
 @compiletime function createSpellbook()
     new AbilityDefinitionSpellBook(ABILITY_ITEM_RADAR)
@@ -218,13 +220,13 @@ function areHostilesNearItem(player p, item itm) returns bool
 
 function getRadarSpells() returns LinkedList<Radar>
     return asList(
-        new Radar(ABILITY_ID_FIND_TINDER   , "Tinders"       , TOOLTIP_EXT_FIND_TINDER   , "ShimmerWeed"     , "Q", 2, 0),
-        new Radar(ABILITY_ID_FIND_STICK    , "Sticks"        , TOOLTIP_EXT_FIND_STICK    , "NatureTouchGrow" , "W", 2, 0),
-        new Radar(ABILITY_ID_FIND_MUSHROOM , "Mushrooms"     , TOOLTIP_EXT_FIND_MANA     , "Mushroom"        , "E", 2, 0),
-        new Radar(ABILITY_ID_FIND_CLAYBALL , "Clay Balls"    , TOOLTIP_EXT_FIND_CLAYBALL , "ThunderLizardEgg", "R", 2, 0),
-        new Radar(ABILITY_ID_FIND_FLINT    , "Flints"        , TOOLTIP_EXT_FIND_FLINT    , "StaffOfSanctuary", "A", 2, 0),
-        new Radar(ABILITY_ID_FIND_STONE    , "Stones"        , TOOLTIP_EXT_FIND_STONE    , "GolemStormBolt"  , "S", 3, 0),
-        new Radar(ABILITY_ID_FIND_MANA     , "Mana Crystals" , TOOLTIP_EXT_FIND_MANA     , "ManaStone"       , "D", 2, 0)
+        new Radar(ABILITY_ID_FIND_TINDER   , "Tinders"       , TOOLTIP_EXT_FIND_TINDER   , "ShimmerWeed"     , "Q", 2, 0, "taunt"),
+        new Radar(ABILITY_ID_FIND_STICK    , "Sticks"        , TOOLTIP_EXT_FIND_STICK    , "NatureTouchGrow" , "W", 2, 0, "tranquility"),
+        new Radar(ABILITY_ID_FIND_MUSHROOM , "Mushrooms"     , TOOLTIP_EXT_FIND_MANA     , "Mushroom"        , "E", 2, 0, "waterelemental"),
+        new Radar(ABILITY_ID_FIND_CLAYBALL , "Clay Balls"    , TOOLTIP_EXT_FIND_CLAYBALL , "ThunderLizardEgg", "R", 2, 0, "unbearform"),
+        new Radar(ABILITY_ID_FIND_FLINT    , "Flints"        , TOOLTIP_EXT_FIND_FLINT    , "StaffOfSanctuary", "A", 2, 0, "bearform"),
+        new Radar(ABILITY_ID_FIND_STONE    , "Stones"        , TOOLTIP_EXT_FIND_STONE    , "GolemStormBolt"  , "S", 3, 0, "unflamingarrows"),
+        new Radar(ABILITY_ID_FIND_MANA     , "Mana Crystals" , TOOLTIP_EXT_FIND_MANA     , "ManaStone"       , "D", 2, 0, "unrobogoblin")
     )
 
 @compiletime function buildRadarSpells()

--- a/wurst/objects/abilities/mage/unsub/ReduceFood.wurst
+++ b/wurst/objects/abilities/mage/unsub/ReduceFood.wurst
@@ -42,6 +42,7 @@ class ReduceFood extends ChannelAbilityPreset
         this.setTooltipNormalExtended(1, TOOLTIP_EXTENDED)
         this.setTooltipNormal(1, makeToolTipNorm(hotkey, TOOLTIP))
         this.setHotkeyNormal(hotkey)
+        this.setBaseOrderID(1, "shockwave")
         this.setButtonPositionNormalX(buttonPos.a)
         this.setButtonPositionNormalX(buttonPos.b)
 

--- a/wurst/objects/abilities/priest/sage/LightGateNew.wurst
+++ b/wurst/objects/abilities/priest/sage/LightGateNew.wurst
@@ -62,6 +62,7 @@ class OpenLightGate extends ChannelAbilityPreset
         this.setArtEffect("")
         this.setArtTarget("")
         this.setArtCaster("")
+        this.setBaseOrderID(1, "waterelemental")
         this.setTargetAttachmentPoint("")
         this.setCasterAttachmentPoint("")
 

--- a/wurst/objects/abilities/priest/unsub/AntiMagic.wurst
+++ b/wurst/objects/abilities/priest/unsub/AntiMagic.wurst
@@ -61,6 +61,7 @@ class AntiMagicAoEDummy extends ChannelAbilityPreset
         this.presetTargetTypes(Targettype.POINT)
         this.setHotkeyNormal(hotkey)
         this.setName(TOOLTIP_NORM)
+        this.setBaseOrderID(1, "antimagicshell")
         this.presetTooltipNormal(lvl -> makeToolTipNorm(hotkey, TOOLTIP_NORM))
         this.presetTooltipNormalExtended(lvl -> TOOLTIP_EXTENDED)
         this.setIconNormal(Icons.bTNAntiMagicShell)

--- a/wurst/objects/abilities/priest/unsub/HealingWave.wurst
+++ b/wurst/objects/abilities/priest/unsub/HealingWave.wurst
@@ -39,6 +39,7 @@ class HealingWave extends ChannelAbilityPreset
         this.presetTargetType(lvl -> 1)
         this.presetTargetsAllowed(lvl -> "air,ground,friend,self,vuln,invu,organic")
         this.setHeroAbility(false)
+        this.setBaseOrderID(1, "healingwave")
         this.setHotkeyNormal(hotkey)
         this.setName(TOOLTIP_NORMAL)
         this.presetTooltipNormal(lvl -> makeToolTipNorm(hotkey, TOOLTIP_NORMAL))

--- a/wurst/objects/abilities/priest/unsub/MixSpells.wurst
+++ b/wurst/objects/abilities/priest/unsub/MixSpells.wurst
@@ -39,6 +39,7 @@ class MixHeat extends ChannelAbilityPreset
         this.setButtonPositionNormalX(buttonPos.a)
         this.setButtonPositionNormalY(buttonPos.b)
         this.setFollowThroughTime(1, 0.5)
+        this.setBaseOrderID(1, "slowoff")
         this.setIconNormal("ReplaceableTextures\\CommandButtons\\BTNHeatDrain.blp")
 
 
@@ -61,6 +62,7 @@ class MixEnergy extends ChannelAbilityPreset
         this.setButtonPositionNormalX(buttonPos.a)
         this.setButtonPositionNormalY(buttonPos.b)
         this.setFollowThroughTime(1, 0.5)
+        this.setBaseOrderID(1, "slow")
         this.setIconNormal(Icons.bTNManaDrain)
 
 

--- a/wurst/objects/abilities/priest/unsub/RangedHeal.wurst
+++ b/wurst/objects/abilities/priest/unsub/RangedHeal.wurst
@@ -37,6 +37,7 @@ class RangedHeal extends ChannelAbilityPreset
         this.presetTargetType(lvl -> 1)
         this.presetTargetsAllowed(lvl -> TARGET_ALLOWED)
         this.presetOptions(lvl -> 1)
+        this.presetBaseOrderID(lvl -> "heal")
         this.setHeroAbility(false)
         this.setHotkeyNormal(hotkey)
         this.setName(TOOLTIP_NORM)

--- a/wurst/objects/abilities/thief/contortionist/NewSmokeStream.wurst
+++ b/wurst/objects/abilities/thief/contortionist/NewSmokeStream.wurst
@@ -53,6 +53,7 @@ class SmokeStream extends ChannelAbilityPreset
         this.setButtonPositionNormalY(buttonPos.b)
         this.setArtCaster(Abilities.obsidianRegenAura)
         this.setEffects(1, Abilities.obsidianRegenAura)
+        this.setBaseOrderID(1, "unsubmerge")
 
 
 @compiletime function createSmokeStream()

--- a/wurst/objects/abilities/thief/escapeArtist/Jump.wurst
+++ b/wurst/objects/abilities/thief/escapeArtist/Jump.wurst
@@ -41,6 +41,8 @@ class Jump extends ChannelAbilityPreset
         this.setButtonPositionNormalY(buttonPos.b)
         this.setCastRange(1, CAST_RANGE)
         this.setArtDuration(1, 0)
+        this.setBaseOrderID(1, "breathoffrost")
+        this.setOrderStringUseTurnOn("breathoffrost")
 
 @compiletime function createJump()
     new Jump(ABILITY_JUMP, "R", new Pair(3, 0))

--- a/wurst/systems/crafting/QuickMakeSpell.wurst
+++ b/wurst/systems/crafting/QuickMakeSpell.wurst
@@ -116,6 +116,7 @@ public class QuickMakeSpell
     let id = '0'
     let btnPositionX = 0
     let btnPositionY = 0
+    let orderId = "channel"
 
     construct(
         string itemName,
@@ -125,7 +126,8 @@ public class QuickMakeSpell
         int btnX,
         int btnY,
         string hotkey,
-        string toolTipEnd
+        string toolTipEnd,
+        string orderId
     )
         this.name = this.name + itemName
         this.toolTip = makeToolTipNorm(hotkey, this.name)
@@ -135,7 +137,7 @@ public class QuickMakeSpell
         this.btnPositionX = btnX
         this.btnPositionY = btnY
         this.hotkey = hotkey
-
+        this.orderId = orderId
 
     function buildSpell()
         new ChannelAbilityPreset(id, 1, true)
@@ -150,6 +152,7 @@ public class QuickMakeSpell
         ..setHotkeyNormal(hotkey)
         ..setButtonPositionNormalX(btnPositionX)
         ..setButtonPositionNormalY(btnPositionY)
+        ..setBaseOrderID(1, orderId)
 
 public class QuickMakeSpellBook
     let id = '0'
@@ -210,149 +213,149 @@ public class QuickMakeSpellBook
 function getQuickMakeSpells() returns LinkedList<QuickMakeSpell>
     return asList(
         // Mixing Pot
-        new QuickMakeSpell("Healing Potion"          , MIX_TOOLTIP+HEALING_POTION_RECIPE          , "LesserRejuvPotion"       , ABILITY_QM_HEALING_POTION          , 0, 0, "Q", QM_TOOLIP),
-        new QuickMakeSpell("Mana Potion"             , MIX_TOOLTIP+MANA_POTION_RECIPE             , "PotionBlueSmall"         , ABILITY_QM_MANA_POTION             , 1, 0, "W", QM_TOOLIP),
-        new QuickMakeSpell("Cure All"                , MIX_TOOLTIP+CURE_ALL_RECIPE                , "LesserClarityPotion"     , ABILITY_QM_CURE_ALL                , 2, 0, "E", QM_TOOLIP),
-        new QuickMakeSpell("Anti-Magic Potion"       , MIX_TOOLTIP+ANTI_MAGIC_POTION_RECIPE       , "PotionOfClarity"         , ABILITY_QM_ANTI_MAGIC_POTION       , 3, 0, "R", QM_TOOLIP),
-        new QuickMakeSpell("Spirit Of Wind"          , MIX_TOOLTIP+SPIRIT_WIND_RECIPE             , "OrbOfLightning"          , ABILITY_QM_SPIRIT_WIND             , 0, 1, "A", QM_TOOLIP),
-        new QuickMakeSpell("Spirit Of Water"         , MIX_TOOLTIP+SPIRIT_WATER_RECIPE            , "OrbOfFrost"              , ABILITY_QM_SPIRIT_WATER            , 1, 1, "S", QM_TOOLIP),
-        new QuickMakeSpell("Spirit Of Darkness"      , MIX_TOOLTIP+SPIRIT_DARKNESS_RECIPE         , "OrbOfDarkness"           , ABILITY_QM_SPIRIT_DARKNESS         , 2, 1, "D", QM_TOOLIP),
-        new QuickMakeSpell("Anabolic Potion"         , MIX_TOOLTIP+ANABOLIC_POTION_RECIPE         , "PotionRed"               , ABILITY_QM_ANABOLIC_POTION         , 0, 2, "Z", QM_TOOLIP),
-        new QuickMakeSpell("Oracle Potion"           , MIX_TOOLTIP+ORACLE_POTION_RECIPE           , "GreaterInvisibility"     , ABILITY_QM_ORACLE_POTION           , 2, 2, "C", QM_TOOLIP),
+        new QuickMakeSpell("Healing Potion"          , MIX_TOOLTIP+HEALING_POTION_RECIPE          , "LesserRejuvPotion"       , ABILITY_QM_HEALING_POTION          , 0, 0, "Q", QM_TOOLIP, "stop"),
+        new QuickMakeSpell("Mana Potion"             , MIX_TOOLTIP+MANA_POTION_RECIPE             , "PotionBlueSmall"         , ABILITY_QM_MANA_POTION             , 1, 0, "W", QM_TOOLIP, "holdposition"),
+        new QuickMakeSpell("Cure All"                , MIX_TOOLTIP+CURE_ALL_RECIPE                , "LesserClarityPotion"     , ABILITY_QM_CURE_ALL                , 2, 0, "E", QM_TOOLIP, "frenzy"),
+        new QuickMakeSpell("Anti-Magic Potion"       , MIX_TOOLTIP+ANTI_MAGIC_POTION_RECIPE       , "PotionOfClarity"         , ABILITY_QM_ANTI_MAGIC_POTION       , 3, 0, "R", QM_TOOLIP, "immolation"),
+        new QuickMakeSpell("Spirit Of Wind"          , MIX_TOOLTIP+SPIRIT_WIND_RECIPE             , "OrbOfLightning"          , ABILITY_QM_SPIRIT_WIND             , 0, 1, "A", QM_TOOLIP, "winwalk"),
+        new QuickMakeSpell("Spirit Of Water"         , MIX_TOOLTIP+SPIRIT_WATER_RECIPE            , "OrbOfFrost"              , ABILITY_QM_SPIRIT_WATER            , 1, 1, "S", QM_TOOLIP, "ambush"),
+        new QuickMakeSpell("Spirit Of Darkness"      , MIX_TOOLTIP+SPIRIT_DARKNESS_RECIPE         , "OrbOfDarkness"           , ABILITY_QM_SPIRIT_DARKNESS         , 2, 1, "D", QM_TOOLIP, "animatedead"),
+        new QuickMakeSpell("Anabolic Potion"         , MIX_TOOLTIP+ANABOLIC_POTION_RECIPE         , "PotionRed"               , ABILITY_QM_ANABOLIC_POTION         , 0, 2, "Z", QM_TOOLIP, "avatar"),
+        new QuickMakeSpell("Oracle Potion"           , MIX_TOOLTIP+ORACLE_POTION_RECIPE           , "GreaterInvisibility"     , ABILITY_QM_ORACLE_POTION           , 2, 2, "C", QM_TOOLIP, "battlestations"),
 
         // Special Herb Page
-        new QuickMakeSpell("Disease Potion"          , MIX_TOOLTIP+DISEASE_POTION_RECIPE          , "PotionGreen"             , ABILITY_QM_DISEASE_POTION          , 0, 0, "Q", QM_TOOLIP),
-        new QuickMakeSpell("Acid Bomb"               , MIX_TOOLTIP+ACID_BOMB_RECIPE               , "AcidBomb"                , ABILITY_QM_ACID_BOMB               , 1, 0, "W", QM_TOOLIP),
-        new QuickMakeSpell("Bee Hive"                , MIX_TOOLTIP+BEE_HIVE_RECIPE                , "Crate"                   , ABILITY_QM_BEE_HIVE                , 2, 0, "E", QM_TOOLIP),
-        new QuickMakeSpell("Essences Of Bees"        , MIX_TOOLTIP+ESSENCE_BEES_RECIPE            , "Crate"                   , ABILITY_QM_ESSENCE_BEES            , 3, 0, "R", QM_TOOLIP),
-        new QuickMakeSpell("Gem Of Knowledge"        , MIX_TOOLTIP+GEM_OF_KNOWLEDGE_RECIPE        , "EnchantedGemstone"       , ABILITY_QM_GEM_OF_KNOWLEDGE        , 0, 1, "A", QM_TOOLIP),
-        new QuickMakeSpell("Omnicure"                , MIX_TOOLTIP+OMNICURE_RECIPE                , "MinorRejuvPotion"        , ABILITY_QM_OMNICURE                , 1, 1, "S", QM_TOOLIP),
-        new QuickMakeSpell("Twin Islands Potion"     , MIX_TOOLTIP+TWIN_ISLANDS_POTION_RECIPE     , "PotionGreenSmall"        , ABILITY_QM_TWIN_ISLANDS            , 2, 1, "D", QM_TOOLIP),
-        new QuickMakeSpell("Nether Potion"           , MIX_TOOLTIP+NETHER_POTION_RECIPE           , "PotionOfOmniscience"     , ABILITY_QM_NETHER_POTION           , 0, 2, "F", QM_TOOLIP),
-        new QuickMakeSpell("Drunks Potion"           , MIX_TOOLTIP+DRUNKS_POTION_RECIPE           , "LesserInvulneralbility"  , ABILITY_QM_DRUNKS_POTION           , 2, 2, "Z", QM_TOOLIP),
-        new QuickMakeSpell("Fervor Potion"           , MIX_TOOLTIP+FERVER_POTION_RECIPE           , "GreaterInvulneralbility" , ABILITY_QM_FERVOR_POTION           , 1, 2, "X", QM_TOOLIP),
-        new QuickMakeSpell("Elemental Shield Potion" , MIX_TOOLTIP+ELEMENTAL_SHIELD_POTION_RECIPE , "PotionOfRestoration"     , ABILITY_QM_ELEMENTAL_SHIELD_POTION , 2, 2, "C", QM_TOOLIP),
+        new QuickMakeSpell("Disease Potion"          , MIX_TOOLTIP+DISEASE_POTION_RECIPE          , "PotionGreen"             , ABILITY_QM_DISEASE_POTION          , 0, 0, "Q", QM_TOOLIP, "berserk"),
+        new QuickMakeSpell("Acid Bomb"               , MIX_TOOLTIP+ACID_BOMB_RECIPE               , "AcidBomb"                , ABILITY_QM_ACID_BOMB               , 1, 0, "W", QM_TOOLIP, "burrow"),
+        new QuickMakeSpell("Bee Hive"                , MIX_TOOLTIP+BEE_HIVE_RECIPE                , "Crate"                   , ABILITY_QM_BEE_HIVE                , 2, 0, "E", QM_TOOLIP, "cannibalize"),
+        new QuickMakeSpell("Essences Of Bees"        , MIX_TOOLTIP+ESSENCE_BEES_RECIPE            , "Crate"                   , ABILITY_QM_ESSENCE_BEES            , 3, 0, "R", QM_TOOLIP, "chemicalrage"),
+        new QuickMakeSpell("Gem Of Knowledge"        , MIX_TOOLTIP+GEM_OF_KNOWLEDGE_RECIPE        , "EnchantedGemstone"       , ABILITY_QM_GEM_OF_KNOWLEDGE        , 0, 1, "A", QM_TOOLIP, "creepanimatedead"),
+        new QuickMakeSpell("Omnicure"                , MIX_TOOLTIP+OMNICURE_RECIPE                , "MinorRejuvPotion"        , ABILITY_QM_OMNICURE                , 1, 1, "S", QM_TOOLIP, "thunderclap"),
+        new QuickMakeSpell("Twin Islands Potion"     , MIX_TOOLTIP+TWIN_ISLANDS_POTION_RECIPE     , "PotionGreenSmall"        , ABILITY_QM_TWIN_ISLANDS            , 2, 1, "D", QM_TOOLIP, "warstomp"),
+        new QuickMakeSpell("Nether Potion"           , MIX_TOOLTIP+NETHER_POTION_RECIPE           , "PotionOfOmniscience"     , ABILITY_QM_NETHER_POTION           , 0, 2, "F", QM_TOOLIP, "defend"),
+        new QuickMakeSpell("Drunks Potion"           , MIX_TOOLTIP+DRUNKS_POTION_RECIPE           , "LesserInvulneralbility"  , ABILITY_QM_DRUNKS_POTION           , 2, 2, "Z", QM_TOOLIP, "divineshield"),
+        new QuickMakeSpell("Fervor Potion"           , MIX_TOOLTIP+FERVER_POTION_RECIPE           , "GreaterInvulneralbility" , ABILITY_QM_FERVOR_POTION           , 1, 2, "X", QM_TOOLIP, "fanofknives"),
+        new QuickMakeSpell("Elemental Shield Potion" , MIX_TOOLTIP+ELEMENTAL_SHIELD_POTION_RECIPE , "PotionOfRestoration"     , ABILITY_QM_ELEMENTAL_SHIELD_POTION , 2, 2, "C", QM_TOOLIP, "howlofterror"),
 
 
         // Armory
-        new QuickMakeSpell("Battle Gloves"        , TRANSMUTE_TOOLTIP+BATTLE_GLOVES_RECIPE        , "ImprovedUnholyStrength" , ABILITY_QM_BATTLE_GLOVES        , 0, 0, "Q", QM_TOOLIP),
-        new QuickMakeSpell("Battle Armor"         , TRANSMUTE_TOOLTIP+BATTLE_ARMOR_RECIPE         , "RobeOfTheMagi"          , ABILITY_QM_BATTLE_ARMOR         , 1, 0, "W", QM_TOOLIP),
-        new QuickMakeSpell("Battle Axe"           , TRANSMUTE_TOOLTIP+BATTLE_AXE_RECIPE           , "OrcMeleeUpThree"        , ABILITY_QM_BATTLE_AXE           , 2, 0, "E", QM_TOOLIP),
-        new QuickMakeSpell("Battle Shield"        , TRANSMUTE_TOOLTIP+BATTLE_SHIELD_RECIPE        , "ArcaniteArmor"          , ABILITY_QM_BATTLE_SHIELD        , 3, 0, "R", QM_TOOLIP),
-        new QuickMakeSpell("Anabolic Boots"       , TRANSMUTE_TOOLTIP+ANABOLIC_BOOTS_RECIPE       , "WirtsOtherLeg"          , ABILITY_QM_ANABOLIC_BOOTS       , 0, 1, "A", QM_TOOLIP),
+        new QuickMakeSpell("Battle Gloves"        , TRANSMUTE_TOOLTIP+BATTLE_GLOVES_RECIPE        , "ImprovedUnholyStrength" , ABILITY_QM_BATTLE_GLOVES        , 0, 0, "Q", QM_TOOLIP, "berserk"),
+        new QuickMakeSpell("Battle Armor"         , TRANSMUTE_TOOLTIP+BATTLE_ARMOR_RECIPE         , "RobeOfTheMagi"          , ABILITY_QM_BATTLE_ARMOR         , 1, 0, "W", QM_TOOLIP, "burrow"),
+        new QuickMakeSpell("Battle Axe"           , TRANSMUTE_TOOLTIP+BATTLE_AXE_RECIPE           , "OrcMeleeUpThree"        , ABILITY_QM_BATTLE_AXE           , 2, 0, "E", QM_TOOLIP, "cannibalize"),
+        new QuickMakeSpell("Battle Shield"        , TRANSMUTE_TOOLTIP+BATTLE_SHIELD_RECIPE        , "ArcaniteArmor"          , ABILITY_QM_BATTLE_SHIELD        , 3, 0, "R", QM_TOOLIP, "chemicalrage"),
+        new QuickMakeSpell("Anabolic Boots"       , TRANSMUTE_TOOLTIP+ANABOLIC_BOOTS_RECIPE       , "WirtsOtherLeg"          , ABILITY_QM_ANABOLIC_BOOTS       , 0, 1, "A", QM_TOOLIP, "fanofknives"),
 
 
         // Witch Doctors Hut
-        new QuickMakeSpell("Scroll Of Entangling Root" , TRANSMUTE_TOOLTIP+SCROLL_ROOT_RECIPE        , "ScrollOfRegenerationGreen" , ABILITY_QM_SCROLL_ROOT        , 0, 0, "Q", QM_TOOLIP),
-        new QuickMakeSpell("Scroll Of Stone Armor"     , TRANSMUTE_TOOLTIP+SCROLL_ARMOR_RECIPE       , "ScrollUber"                , ABILITY_QM_SCROLL_ARMOR       , 1, 0, "W", QM_TOOLIP),
-        new QuickMakeSpell("Scroll Of Tsunami"         , TRANSMUTE_TOOLTIP+SCROLL_TSUNAMI_RECIPE     , "SnazzyScrollPurple"        , ABILITY_QM_SCROLL_TSUNAMI     , 2, 0, "E", QM_TOOLIP),
-        new QuickMakeSpell("Scroll Of Living Dead"     , TRANSMUTE_TOOLTIP+SCROLL_LIVING_DEAD_RECIPE , "SnazzyScroll"              , ABILITY_QM_SCROLL_LIVING_DEAD , 3, 0, "R", QM_TOOLIP),
-        new QuickMakeSpell("Scroll Of Fireball"        , TRANSMUTE_TOOLTIP+SCROLL_FIREBALL_RECIPE    , "ScrollOfHealing"           , ABILITY_QM_SCROLL_FIREBALL    , 2, 2, "Q", QM_TOOLIP),
-        new QuickMakeSpell("Scroll Of Cyclone"         , TRANSMUTE_TOOLTIP+SCROLL_CYCLONE_RECIPE     , "BansheeMaster"             , ABILITY_QM_SCROLL_CYCLONE     , 2, 2, "W", QM_TOOLIP),
-        new QuickMakeSpell("Scroll Of Swiftness"       , TRANSMUTE_TOOLTIP+SCROLL_SWIFTNESS_RECIPE   , "ScrollOfHaste"             , ABILITY_QM_SCROLL_SWIFTNESS   , 2, 2, "E", QM_TOOLIP),
-        new QuickMakeSpell("Cloak Of Flames"           , TRANSMUTE_TOOLTIP+CLOAK_FLAMES_RECIPE       , "CloakOfInferno"            , ABILITY_QM_CLOAK_FLAMES       , 0, 1, "A", QM_TOOLIP),
-        new QuickMakeSpell("Cloak Of Frost"            , TRANSMUTE_TOOLTIP+CLOAK_FROST_RECIPE        , "CloakOfFrost"              , ABILITY_QM_CLOAK_FROST        , 1, 1, "S", QM_TOOLIP),
-        new QuickMakeSpell("Cloak Of Healing"          , TRANSMUTE_TOOLTIP+CLOAK_HEALING_RECIPE      , "CloakOfHealing"            , ABILITY_QM_CLOAK_HEALING      , 2, 1, "D", QM_TOOLIP),
-        new QuickMakeSpell("Cloak Of Mana"             , TRANSMUTE_TOOLTIP+CLOAK_MANA_RECIPE         , "CloakOfMana"               , ABILITY_QM_CLOAK_MANA         , 3, 1, "F", QM_TOOLIP),
+        new QuickMakeSpell("Scroll Of Entangling Root" , TRANSMUTE_TOOLTIP+SCROLL_ROOT_RECIPE        , "ScrollOfRegenerationGreen" , ABILITY_QM_SCROLL_ROOT        , 0, 0, "Q", QM_TOOLIP, "berserk"),
+        new QuickMakeSpell("Scroll Of Stone Armor"     , TRANSMUTE_TOOLTIP+SCROLL_ARMOR_RECIPE       , "ScrollUber"                , ABILITY_QM_SCROLL_ARMOR       , 1, 0, "W", QM_TOOLIP, "burrow"),
+        new QuickMakeSpell("Scroll Of Tsunami"         , TRANSMUTE_TOOLTIP+SCROLL_TSUNAMI_RECIPE     , "SnazzyScrollPurple"        , ABILITY_QM_SCROLL_TSUNAMI     , 2, 0, "E", QM_TOOLIP, "cannibalize"),
+        new QuickMakeSpell("Scroll Of Living Dead"     , TRANSMUTE_TOOLTIP+SCROLL_LIVING_DEAD_RECIPE , "SnazzyScroll"              , ABILITY_QM_SCROLL_LIVING_DEAD , 3, 0, "R", QM_TOOLIP, "chemicalrage"),
+        new QuickMakeSpell("Scroll Of Fireball"        , TRANSMUTE_TOOLTIP+SCROLL_FIREBALL_RECIPE    , "ScrollOfHealing"           , ABILITY_QM_SCROLL_FIREBALL    , 2, 2, "Q", QM_TOOLIP, "creepanimatedead"),
+        new QuickMakeSpell("Scroll Of Cyclone"         , TRANSMUTE_TOOLTIP+SCROLL_CYCLONE_RECIPE     , "BansheeMaster"             , ABILITY_QM_SCROLL_CYCLONE     , 2, 2, "W", QM_TOOLIP, "thunderclap"),
+        new QuickMakeSpell("Scroll Of Swiftness"       , TRANSMUTE_TOOLTIP+SCROLL_SWIFTNESS_RECIPE   , "ScrollOfHaste"             , ABILITY_QM_SCROLL_SWIFTNESS   , 2, 2, "E", QM_TOOLIP, "warstomp"),
+        new QuickMakeSpell("Cloak Of Flames"           , TRANSMUTE_TOOLTIP+CLOAK_FLAMES_RECIPE       , "CloakOfInferno"            , ABILITY_QM_CLOAK_FLAMES       , 0, 1, "A", QM_TOOLIP, "defend"),
+        new QuickMakeSpell("Cloak Of Frost"            , TRANSMUTE_TOOLTIP+CLOAK_FROST_RECIPE        , "CloakOfFrost"              , ABILITY_QM_CLOAK_FROST        , 1, 1, "S", QM_TOOLIP, "divineshield"),
+        new QuickMakeSpell("Cloak Of Healing"          , TRANSMUTE_TOOLTIP+CLOAK_HEALING_RECIPE      , "CloakOfHealing"            , ABILITY_QM_CLOAK_HEALING      , 2, 1, "D", QM_TOOLIP, "fanofknives"),
+        new QuickMakeSpell("Cloak Of Mana"             , TRANSMUTE_TOOLTIP+CLOAK_MANA_RECIPE         , "CloakOfMana"               , ABILITY_QM_CLOAK_MANA         , 3, 1, "F", QM_TOOLIP, "howlofterror"),
 
         // Second Page
-        new QuickMakeSpell("Magic Seed"                , TRANSMUTE_TOOLTIP+MAGIC_SEED_RECIPE         , "Root"                      , ABILITY_QM_MAGIC_SEED         , 2, 2, "A", QM_TOOLIP),
-        new QuickMakeSpell("Spirit Ward"               , TRANSMUTE_TOOLTIP+SPIRIT_WARD_RECIPE        , "AbsorbMagic"               , ABILITY_QM_SPIRIT_WARD        , 2, 2, "S", QM_TOOLIP),
-        new QuickMakeSpell("Poison"                    , TRANSMUTE_TOOLTIP+POISON_RECIPE             , "HealingSalve"              , ABILITY_QM_POISON             , 0, 2, "Z", QM_TOOLIP),
-        new QuickMakeSpell("Ultra Poison"              , TRANSMUTE_TOOLTIP+ULTRA_POISON_RECIPE       , "VialFull"                  , ABILITY_QM_ULTRA_POISON       , 1, 2, "X", QM_TOOLIP),
+        new QuickMakeSpell("Living Clay"               , TRANSMUTE_TOOLTIP+LIVING_CLAY_RECIPE        , "GreenSentryWard"           , ABILITY_QM_LIVING_CLAY        , 2, 2, "R", QM_TOOLIP, "locustswarm"),
+        new QuickMakeSpell("Magic Seed"                , TRANSMUTE_TOOLTIP+MAGIC_SEED_RECIPE         , "Root"                      , ABILITY_QM_MAGIC_SEED         , 2, 2, "A", QM_TOOLIP, "manashieldon"),
+        new QuickMakeSpell("Spirit Ward"               , TRANSMUTE_TOOLTIP+SPIRIT_WARD_RECIPE        , "AbsorbMagic"               , ABILITY_QM_SPIRIT_WARD        , 2, 2, "S", QM_TOOLIP, "manaflareoff"),
+        new QuickMakeSpell("Poison"                    , TRANSMUTE_TOOLTIP+POISON_RECIPE             , "HealingSalve"              , ABILITY_QM_POISON             , 0, 2, "Z", QM_TOOLIP, "manaflareon"),
+        new QuickMakeSpell("Ultra Poison"              , TRANSMUTE_TOOLTIP+ULTRA_POISON_RECIPE       , "VialFull"                  , ABILITY_QM_ULTRA_POISON       , 1, 2, "X", QM_TOOLIP, "manashieldoff"),
 
 
         // Workshop
-        new QuickMakeSpell("Ensnare Trap"         , TRANSMUTE_TOOLTIP+ENSNARE_TRAP_RECIPE         , "COP"                    , ABILITY_QM_ENSNARE_TRAP         , 0, 0, "Q", QM_TOOLIP),
-        new QuickMakeSpell("Mana Crystal"         , TRANSMUTE_TOOLTIP+MANA_CRYSTAL_RECIPE         , "ManaCrystal"            , ABILITY_QM_MANA_CRYSTAL         , 1, 0, "W", QM_TOOLIP),
-        new QuickMakeSpell("Blow Gun"             , TRANSMUTE_TOOLTIP+BLOW_GUN_RECIPE             , "AlleriaFlute"           , ABILITY_QM_BLOW_GUN             , 2, 0, "E", QM_TOOLIP),
-        new QuickMakeSpell("Dark Thistles"        , TRANSMUTE_TOOLTIP+DARK_THISTLES_RECIPE        , "QuillSpray"             , ABILITY_QM_DARK_THISTLES        , 3, 0, "R", QM_TOOLIP),
-        new QuickMakeSpell("Poison Spear"         , TRANSMUTE_TOOLTIP+POISON_SPEAR_RECIPE         , "PoisonSpear"            , ABILITY_QM_POISON_SPEAR         , 0, 1, "A", QM_TOOLIP),
-        new QuickMakeSpell("Refined Poison Spear" , TRANSMUTE_TOOLTIP+REFINED_POISON_SPEAR_RECIPE , "EnvenomedSpear"         , ABILITY_QM_REFINED_POISON_SPEAR , 1, 1, "S", QM_TOOLIP),
-        new QuickMakeSpell("Ultra Poison Spear"   , TRANSMUTE_TOOLTIP+ULTRA_POISON_SPEAR_RECIPE   , "UltraPoisonSpear"       , ABILITY_QM_ULTRA_POISON_SPEAR   , 2, 1, "D", QM_TOOLIP),
-        new QuickMakeSpell("Nets"                 , TRANSMUTE_TOOLTIP+NETS_RECIPE                 , "Ensnare"                , ABILITY_QM_NETS                 , 0, 2, "Z", QM_TOOLIP),
-        new QuickMakeSpell("Hunting Net"          , TRANSMUTE_TOOLTIP+HUNTING_NET_RECIPE          , "HuntingNet"             , ABILITY_QM_HUNTING_NET          , 1, 2, "X", QM_TOOLIP),
-        new QuickMakeSpell("Living Clay"          , TRANSMUTE_TOOLTIP+LIVING_CLAY_RECIPE          , "GreenSentryWard"        , ABILITY_QM_LIVING_CLAY          , 3, 1, "F", QM_TOOLIP),
+        new QuickMakeSpell("Ensnare Trap"         , TRANSMUTE_TOOLTIP+ENSNARE_TRAP_RECIPE         , "COP"                    , ABILITY_QM_ENSNARE_TRAP         , 0, 0, "Q", QM_TOOLIP, "immolation"),
+        new QuickMakeSpell("Mana Crystal"         , TRANSMUTE_TOOLTIP+MANA_CRYSTAL_RECIPE         , "ManaCrystal"            , ABILITY_QM_MANA_CRYSTAL         , 1, 0, "W", QM_TOOLIP, "manashieldon"),
+        new QuickMakeSpell("Blow Gun"             , TRANSMUTE_TOOLTIP+BLOW_GUN_RECIPE             , "AlleriaFlute"           , ABILITY_QM_BLOW_GUN             , 2, 0, "E", QM_TOOLIP, "divineshield"),
+        new QuickMakeSpell("Dark Thistles"        , TRANSMUTE_TOOLTIP+DARK_THISTLES_RECIPE        , "QuillSpray"             , ABILITY_QM_DARK_THISTLES        , 3, 0, "R", QM_TOOLIP, "berserk"),
+        new QuickMakeSpell("Poison Spear"         , TRANSMUTE_TOOLTIP+POISON_SPEAR_RECIPE         , "PoisonSpear"            , ABILITY_QM_POISON_SPEAR         , 0, 1, "A", QM_TOOLIP, "creepanimatedead"),
+        new QuickMakeSpell("Refined Poison Spear" , TRANSMUTE_TOOLTIP+REFINED_POISON_SPEAR_RECIPE , "EnvenomedSpear"         , ABILITY_QM_REFINED_POISON_SPEAR , 1, 1, "S", QM_TOOLIP, "thunderclap"),
+        new QuickMakeSpell("Ultra Poison Spear"   , TRANSMUTE_TOOLTIP+ULTRA_POISON_SPEAR_RECIPE   , "UltraPoisonSpear"       , ABILITY_QM_ULTRA_POISON_SPEAR   , 2, 1, "D", QM_TOOLIP, "warstomp"),
+        new QuickMakeSpell("Nets"                 , TRANSMUTE_TOOLTIP+NETS_RECIPE                 , "Ensnare"                , ABILITY_QM_NETS                 , 0, 2, "Z", QM_TOOLIP, "defend"),
+        new QuickMakeSpell("Hunting Net"          , TRANSMUTE_TOOLTIP+HUNTING_NET_RECIPE          , "HuntingNet"             , ABILITY_QM_HUNTING_NET          , 1, 2, "X", QM_TOOLIP, "howlofterror"),
 
         // Second Page
-        new QuickMakeSpell("Smoke Bomb"           , TRANSMUTE_TOOLTIP+SMOKE_BOMB_RECIPE           , "SmokePot"               , ABILITY_QM_SMOKE_BOMB           , 0, 0, "Q", QM_TOOLIP),
-        new QuickMakeSpell("Fire Bomb"            , TRANSMUTE_TOOLTIP+FIRE_BOMB_RECIPE            , "LiquidFire"             , ABILITY_QM_FIRE_BOMB            , 1, 0, "W", QM_TOOLIP),
-        new QuickMakeSpell("EMP"                  , TRANSMUTE_TOOLTIP+EMP_RECIPE                  , "WispSplode"             , ABILITY_QM_EMP                  , 2, 0, "E", QM_TOOLIP),
-        new QuickMakeSpell("Transport Ship"       , TRANSMUTE_TOOLTIP+TRANSPORT_SHIP_RECIPE       , "NightElfTransport"      , ABILITY_QM_TRANSPORT_SHIP       , 3, 0, "R", QM_TOOLIP),
+        new QuickMakeSpell("Smoke Bomb"           , TRANSMUTE_TOOLTIP+SMOKE_BOMB_RECIPE           , "SmokePot"               , ABILITY_QM_SMOKE_BOMB           , 0, 0, "Q", QM_TOOLIP, "locustswarm"),
+        new QuickMakeSpell("Fire Bomb"            , TRANSMUTE_TOOLTIP+FIRE_BOMB_RECIPE            , "LiquidFire"             , ABILITY_QM_FIRE_BOMB            , 1, 0, "W", QM_TOOLIP, "manashieldon"),
+        new QuickMakeSpell("EMP"                  , TRANSMUTE_TOOLTIP+EMP_RECIPE                  , "WispSplode"             , ABILITY_QM_EMP                  , 2, 0, "E", QM_TOOLIP, "manaflareoff"),
+        new QuickMakeSpell("Transport Ship"       , TRANSMUTE_TOOLTIP+TRANSPORT_SHIP_RECIPE       , "NightElfTransport"      , ABILITY_QM_TRANSPORT_SHIP       , 3, 0, "R", QM_TOOLIP, "manaflareon"),
 
 
 
         // Tannery
-        new QuickMakeSpell("Elk Skin Boots"          , TRANSMUTE_TOOLTIP+ELK_SKIN_BOOTS_RECIPE          , "ElkHideBoots"   , ABILITY_QM_ELK_SKIN_BOOTS          , 0, 0, "Q", QM_TOOLIP),
-        new QuickMakeSpell("Elk Skin Gloves"         , TRANSMUTE_TOOLTIP+ELK_SKIN_GLOVES_RECIPE         , "ElkHideGloves"  , ABILITY_QM_ELK_SKIN_GLOVES         , 1, 0, "W", QM_TOOLIP),
-        new QuickMakeSpell("Elk Skin Coat"           , TRANSMUTE_TOOLTIP+ELK_SKIN_COAT_RECIPE           , "ElkHideCoat"    , ABILITY_QM_ELK_SKIN_COAT           , 2, 0, "E", QM_TOOLIP),
-        new QuickMakeSpell("Jungle Wolf Skin Boots"  , TRANSMUTE_TOOLTIP+JUNGLE_WOLF_SKIN_BOOTS_RECIPE  , "WolfHideBoots"  , ABILITY_QM_JUNGLE_WOLF_SKIN_BOOTS  , 0, 1, "A", QM_TOOLIP),
-        new QuickMakeSpell("Jungle Wolf Skin Gloves" , TRANSMUTE_TOOLTIP+JUNGLE_WOLF_SKIN_GLOVES_RECIPE , "WolfHideGloves" , ABILITY_QM_JUNGLE_WOLF_SKIN_GLOVES , 1, 1, "S", QM_TOOLIP),
-        new QuickMakeSpell("Jungle Wolf Skin Coat"   , TRANSMUTE_TOOLTIP+JUNGLE_WOLF_SKIN_COAT_RECIPE   , "WolfHideCoat"   , ABILITY_QM_JUNGLE_WOLF_SKIN_COAT   , 2, 1, "D", QM_TOOLIP),
-        new QuickMakeSpell("Jungle Bear Skin Boots"  , TRANSMUTE_TOOLTIP+JUNGLE_BEAR_SKIN_BOOTS_RECIPE  , "BearHideBoots"  , ABILITY_QM_JUNGLE_BEAR_SKIN_BOOTS  , 0, 2, "Z", QM_TOOLIP),
-        new QuickMakeSpell("Jungle Bear Skin Gloves" , TRANSMUTE_TOOLTIP+JUNGLE_BEAR_SKIN_GLOVES_RECIPE , "BearHideGloves" , ABILITY_QM_JUNGLE_BEAR_SKIN_GLOVES , 1, 2, "X", QM_TOOLIP),
-        new QuickMakeSpell("Jungle Bear Skin Coat"   , TRANSMUTE_TOOLTIP+JUNGLE_BEAR_SKIN_COAT_RECIPE   , "BearHideCoat"   , ABILITY_QM_JUNGLE_BEAR_SKIN_COAT   , 2, 2, "C", QM_TOOLIP),
+        new QuickMakeSpell("Elk Skin Boots"          , TRANSMUTE_TOOLTIP+ELK_SKIN_BOOTS_RECIPE          , "ElkHideBoots"   , ABILITY_QM_ELK_SKIN_BOOTS          , 0, 0, "Q", QM_TOOLIP, "berserk"),
+        new QuickMakeSpell("Elk Skin Gloves"         , TRANSMUTE_TOOLTIP+ELK_SKIN_GLOVES_RECIPE         , "ElkHideGloves"  , ABILITY_QM_ELK_SKIN_GLOVES         , 1, 0, "W", QM_TOOLIP, "burrow"),
+        new QuickMakeSpell("Elk Skin Coat"           , TRANSMUTE_TOOLTIP+ELK_SKIN_COAT_RECIPE           , "ElkHideCoat"    , ABILITY_QM_ELK_SKIN_COAT           , 2, 0, "E", QM_TOOLIP, "cannibalize"),
+        new QuickMakeSpell("Jungle Wolf Skin Boots"  , TRANSMUTE_TOOLTIP+JUNGLE_WOLF_SKIN_BOOTS_RECIPE  , "WolfHideBoots"  , ABILITY_QM_JUNGLE_WOLF_SKIN_BOOTS  , 0, 1, "A", QM_TOOLIP, "chemicalrage"),
+        new QuickMakeSpell("Jungle Wolf Skin Gloves" , TRANSMUTE_TOOLTIP+JUNGLE_WOLF_SKIN_GLOVES_RECIPE , "WolfHideGloves" , ABILITY_QM_JUNGLE_WOLF_SKIN_GLOVES , 1, 1, "S", QM_TOOLIP, "creepanimatedead"),
+        new QuickMakeSpell("Jungle Wolf Skin Coat"   , TRANSMUTE_TOOLTIP+JUNGLE_WOLF_SKIN_COAT_RECIPE   , "WolfHideCoat"   , ABILITY_QM_JUNGLE_WOLF_SKIN_COAT   , 2, 1, "D", QM_TOOLIP, "thunderclap"),
+        new QuickMakeSpell("Jungle Bear Skin Boots"  , TRANSMUTE_TOOLTIP+JUNGLE_BEAR_SKIN_BOOTS_RECIPE  , "BearHideBoots"  , ABILITY_QM_JUNGLE_BEAR_SKIN_BOOTS  , 0, 2, "Z", QM_TOOLIP, "warstomp"),
+        new QuickMakeSpell("Jungle Bear Skin Gloves" , TRANSMUTE_TOOLTIP+JUNGLE_BEAR_SKIN_GLOVES_RECIPE , "BearHideGloves" , ABILITY_QM_JUNGLE_BEAR_SKIN_GLOVES , 1, 2, "X", QM_TOOLIP, "defend"),
+        new QuickMakeSpell("Jungle Bear Skin Coat"   , TRANSMUTE_TOOLTIP+JUNGLE_BEAR_SKIN_COAT_RECIPE   , "BearHideCoat"   , ABILITY_QM_JUNGLE_BEAR_SKIN_COAT   , 2, 2, "C", QM_TOOLIP, "divineshield"),
 
         // Hydra
-        new QuickMakeSpell("Hydra Scale Boots"          , TRANSMUTE_TOOLTIP+HYDRA_SCALE_BOOTS_RECIPE          , "HydraWarStomp"   , ABILITY_QM_HYDRA_SCALE_BOOTS          , 0, 0, "Q", QM_TOOLIP),
-        new QuickMakeSpell("Hydra Scale Gloves"         , TRANSMUTE_TOOLTIP+HYDRA_SCALE_GLOVES_RECIPE         , "ImprovedStrengthOfTheWild"  , ABILITY_QM_HYDRA_SCALE_GLOVES         , 1, 0, "W", QM_TOOLIP),
-        new QuickMakeSpell("Hydra Scale Coat"           , TRANSMUTE_TOOLTIP+HYDRA_SCALE_COAT_RECIPE           , "NagaArmorUp3"    , ABILITY_QM_HYDRA_SCALE_COAT           , 2, 0, "E", QM_TOOLIP),
+        new QuickMakeSpell("Hydra Scale Boots"          , TRANSMUTE_TOOLTIP+HYDRA_SCALE_BOOTS_RECIPE          , "HydraWarStomp"   , ABILITY_QM_HYDRA_SCALE_BOOTS          , 0, 0, "Q", QM_TOOLIP, "berserk"),
+        new QuickMakeSpell("Hydra Scale Gloves"         , TRANSMUTE_TOOLTIP+HYDRA_SCALE_GLOVES_RECIPE         , "ImprovedStrengthOfTheWild"  , ABILITY_QM_HYDRA_SCALE_GLOVES         , 1, 0, "W", QM_TOOLIP, "burrow"),
+        new QuickMakeSpell("Hydra Scale Coat"           , TRANSMUTE_TOOLTIP+HYDRA_SCALE_COAT_RECIPE           , "NagaArmorUp3"    , ABILITY_QM_HYDRA_SCALE_COAT           , 2, 0, "E", QM_TOOLIP, "cannibalize"),
 
         //Forge
 
 
-        new QuickMakeSpell("Spear"        , TRANSMUTE_TOOLTIP+SPEAR_RECIPE        , "SteelRanged"                , ABILITY_QM_SPEAR        , 0, 0, "Q", QM_TOOLIP),
-        new QuickMakeSpell("Iron Spear"   , TRANSMUTE_TOOLTIP+IRON_SPEAR_RECIPE   , "StrengthOfTheMoon"          , ABILITY_QM_IRON_SPEAR   , 1, 0, "W", QM_TOOLIP),
-        new QuickMakeSpell("Steel Spear"  , TRANSMUTE_TOOLTIP+STEEL_SPEAR_RECIPE  , "ThoriumRanged"              , ABILITY_QM_STEEL_SPEAR  , 2, 0, "E", QM_TOOLIP),
-        new QuickMakeSpell("Dark Spear"   , TRANSMUTE_TOOLTIP+DARK_SPEAR_RECIPE   , "ArcaniteRanged"             , ABILITY_QM_DARK_SPEAR   , 3, 0, "R", QM_TOOLIP),
-        new QuickMakeSpell("Iron Axe"     , TRANSMUTE_TOOLTIP+IRON_AXE_RECIPE     , "OrcMeleeUpTwo"              , ABILITY_QM_IRON_AXE     , 0, 1, "A", QM_TOOLIP),
-        new QuickMakeSpell("Steel Axe"    , TRANSMUTE_TOOLTIP+STEEL_AXE_RECIPE    , "SpiritWalkerAdeptTraining"  , ABILITY_QM_STEEL_AXE    , 1, 1, "S", QM_TOOLIP),
-        new QuickMakeSpell("Mage Masher"  , TRANSMUTE_TOOLTIP+MAGE_MASHER_RECIPE  , "SpiritWalkerMasterTraining" , ABILITY_QM_MAGE_MASHER  , 2, 1, "D", QM_TOOLIP),
-        new QuickMakeSpell("Iron Ingot"   , TRANSMUTE_TOOLTIP+IRON_INGOT_RECIPE   , "IronIngot"                  , ABILITY_QM_IRON_INGOT   , 0, 2, "Z", QM_TOOLIP),
-        new QuickMakeSpell("Steel Ingot"  , TRANSMUTE_TOOLTIP+STEEL_INGOT_RECIPE  , "SteelIngot"                 , ABILITY_QM_STEEL_INGOT  , 1, 2, "X", QM_TOOLIP),
+        new QuickMakeSpell("Spear"        , TRANSMUTE_TOOLTIP+SPEAR_RECIPE        , "SteelRanged"                , ABILITY_QM_SPEAR        , 0, 0, "Q", QM_TOOLIP, "stop"),
+        new QuickMakeSpell("Iron Spear"   , TRANSMUTE_TOOLTIP+IRON_SPEAR_RECIPE   , "StrengthOfTheMoon"          , ABILITY_QM_IRON_SPEAR   , 1, 0, "W", QM_TOOLIP, "holdposition"),
+        new QuickMakeSpell("Steel Spear"  , TRANSMUTE_TOOLTIP+STEEL_SPEAR_RECIPE  , "ThoriumRanged"              , ABILITY_QM_STEEL_SPEAR  , 2, 0, "E", QM_TOOLIP, "frenzy"),
+        new QuickMakeSpell("Dark Spear"   , TRANSMUTE_TOOLTIP+DARK_SPEAR_RECIPE   , "ArcaniteRanged"             , ABILITY_QM_DARK_SPEAR   , 3, 0, "R", QM_TOOLIP, "manashieldoff"),
+        new QuickMakeSpell("Iron Axe"     , TRANSMUTE_TOOLTIP+IRON_AXE_RECIPE     , "OrcMeleeUpTwo"              , ABILITY_QM_IRON_AXE     , 0, 1, "A", QM_TOOLIP, "ambush"),
+        new QuickMakeSpell("Steel Axe"    , TRANSMUTE_TOOLTIP+STEEL_AXE_RECIPE    , "SpiritWalkerAdeptTraining"  , ABILITY_QM_STEEL_AXE    , 1, 1, "S", QM_TOOLIP, "animatedead"),
+        new QuickMakeSpell("Mage Masher"  , TRANSMUTE_TOOLTIP+MAGE_MASHER_RECIPE  , "SpiritWalkerMasterTraining" , ABILITY_QM_MAGE_MASHER  , 2, 1, "D", QM_TOOLIP, "mirrorimage"),
+        new QuickMakeSpell("Iron Ingot"   , TRANSMUTE_TOOLTIP+IRON_INGOT_RECIPE   , "IronIngot"                  , ABILITY_QM_IRON_INGOT   , 0, 2, "Z", QM_TOOLIP, "avatar"),
+        new QuickMakeSpell("Steel Ingot"  , TRANSMUTE_TOOLTIP+STEEL_INGOT_RECIPE  , "SteelIngot"                 , ABILITY_QM_STEEL_INGOT  , 1, 2, "X", QM_TOOLIP, "battlestations"),
 
 
         //Second Forge Page
-        new QuickMakeSpell("Shield"       , TRANSMUTE_TOOLTIP+SHIELD_RECIPE       , "SteelArmor"                 , ABILITY_QM_SHIELD       , 0, 0, "Q", QM_TOOLIP),
-        new QuickMakeSpell("Bone Shield"  , TRANSMUTE_TOOLTIP+BONE_SHIELD_RECIPE  , "ImprovedUnholyArmor"        , ABILITY_QM_BONE_SHIELD  , 1, 0, "W", QM_TOOLIP),
-        new QuickMakeSpell("Iron Shield"  , TRANSMUTE_TOOLTIP+IRON_SHIELD_RECIPE  , "HumanArmorUpOne"            , ABILITY_QM_IRON_SHIELD  , 2, 0, "E", QM_TOOLIP),
-        new QuickMakeSpell("Steel Shield" , TRANSMUTE_TOOLTIP+STEEL_SHIELD_RECIPE , "ThoriumArmor"               , ABILITY_QM_STEEL_SHIELD , 3, 0, "R", QM_TOOLIP),
+        new QuickMakeSpell("Shield"       , TRANSMUTE_TOOLTIP+SHIELD_RECIPE       , "SteelArmor"                 , ABILITY_QM_SHIELD       , 0, 0, "Q", QM_TOOLIP, "locustswarm"),
+        new QuickMakeSpell("Bone Shield"  , TRANSMUTE_TOOLTIP+BONE_SHIELD_RECIPE  , "ImprovedUnholyArmor"        , ABILITY_QM_BONE_SHIELD  , 1, 0, "W", QM_TOOLIP, "manashieldon"),
+        new QuickMakeSpell("Iron Shield"  , TRANSMUTE_TOOLTIP+IRON_SHIELD_RECIPE  , "HumanArmorUpOne"            , ABILITY_QM_IRON_SHIELD  , 2, 0, "E", QM_TOOLIP, "manaflareoff"),
+        new QuickMakeSpell("Steel Shield" , TRANSMUTE_TOOLTIP+STEEL_SHIELD_RECIPE , "ThoriumArmor"               , ABILITY_QM_STEEL_SHIELD , 3, 0, "R", QM_TOOLIP, "manaflareon"),
 
         // Armor Page in Forge
-        new QuickMakeSpell("Bone Boots"   , TRANSMUTE_TOOLTIP+BONE_BOOTS_RECIPE   , "BoneBoots"                  , ABILITY_QM_BONE_BOOTS   , 0, 0, "Q", QM_TOOLIP),
-        new QuickMakeSpell("Iron Boots"   , TRANSMUTE_TOOLTIP+IRON_BOOTS_RECIPE   , "Boots"                      , ABILITY_QM_IRON_BOOTS   , 1, 0, "W", QM_TOOLIP),
-        new QuickMakeSpell("Steel Boots"  , TRANSMUTE_TOOLTIP+STEEL_BOOTS_RECIPE  , "SteelBoots"                 , ABILITY_QM_STEEL_BOOTS  , 2, 0, "E", QM_TOOLIP),
-        new QuickMakeSpell("Bone Gloves"  , TRANSMUTE_TOOLTIP+BONE_GLOVES_RECIPE  , "GauntletsOfOgrePower"       , ABILITY_QM_BONE_GLOVES  , 0, 1, "A", QM_TOOLIP),
-        new QuickMakeSpell("Iron Gloves"  , TRANSMUTE_TOOLTIP+IRON_GLOVES_RECIPE  , "IronGloves"                 , ABILITY_QM_IRON_GLOVES  , 1, 1, "S", QM_TOOLIP),
-        new QuickMakeSpell("Steel Gloves" , TRANSMUTE_TOOLTIP+STEEL_GLOVES_RECIPE , "AdvancedUnholyStrength"     , ABILITY_QM_STEEL_GLOVES , 2, 1, "D", QM_TOOLIP),
-        new QuickMakeSpell("Bone Coat"    , TRANSMUTE_TOOLTIP+BONE_COAT_RECIPE    , "BoneCoat"                   , ABILITY_QM_BONE_COAT    , 0, 2, "Z", QM_TOOLIP),
-        new QuickMakeSpell("Iron Coat"    , TRANSMUTE_TOOLTIP+IRON_COAT_RECIPE    , "ImprovedMoonArmor"          , ABILITY_QM_IRON_COAT    , 1, 2, "X", QM_TOOLIP),
-        new QuickMakeSpell("Steel Coat"   , TRANSMUTE_TOOLTIP+STEEL_COAT_RECIPE   , "AdvancedMoonArmor"          , ABILITY_QM_STEEL_COAT   , 2, 2, "C", QM_TOOLIP),
+        new QuickMakeSpell("Bone Boots"   , TRANSMUTE_TOOLTIP+BONE_BOOTS_RECIPE   , "BoneBoots"                  , ABILITY_QM_BONE_BOOTS   , 0, 0, "Q", QM_TOOLIP, "berserk"),
+        new QuickMakeSpell("Iron Boots"   , TRANSMUTE_TOOLTIP+IRON_BOOTS_RECIPE   , "Boots"                      , ABILITY_QM_IRON_BOOTS   , 1, 0, "W", QM_TOOLIP, "burrow"),
+        new QuickMakeSpell("Steel Boots"  , TRANSMUTE_TOOLTIP+STEEL_BOOTS_RECIPE  , "SteelBoots"                 , ABILITY_QM_STEEL_BOOTS  , 2, 0, "E", QM_TOOLIP, "cannibalize"),
+        new QuickMakeSpell("Bone Gloves"  , TRANSMUTE_TOOLTIP+BONE_GLOVES_RECIPE  , "GauntletsOfOgrePower"       , ABILITY_QM_BONE_GLOVES  , 0, 1, "A", QM_TOOLIP, "chemicalrage"),
+        new QuickMakeSpell("Iron Gloves"  , TRANSMUTE_TOOLTIP+IRON_GLOVES_RECIPE  , "IronGloves"                 , ABILITY_QM_IRON_GLOVES  , 1, 1, "S", QM_TOOLIP, "creepanimatedead"),
+        new QuickMakeSpell("Steel Gloves" , TRANSMUTE_TOOLTIP+STEEL_GLOVES_RECIPE , "AdvancedUnholyStrength"     , ABILITY_QM_STEEL_GLOVES , 2, 1, "D", QM_TOOLIP, "thunderclap"),
+        new QuickMakeSpell("Bone Coat"    , TRANSMUTE_TOOLTIP+BONE_COAT_RECIPE    , "BoneCoat"                   , ABILITY_QM_BONE_COAT    , 0, 2, "Z", QM_TOOLIP, "warstomp"),
+        new QuickMakeSpell("Iron Coat"    , TRANSMUTE_TOOLTIP+IRON_COAT_RECIPE    , "ImprovedMoonArmor"          , ABILITY_QM_IRON_COAT    , 1, 2, "X", QM_TOOLIP, "defend"),
+        new QuickMakeSpell("Steel Coat"   , TRANSMUTE_TOOLTIP+STEEL_COAT_RECIPE   , "AdvancedMoonArmor"          , ABILITY_QM_STEEL_COAT   , 2, 2, "C", QM_TOOLIP, "divineshield"),
 
         // Those are placeholder for tannery, just to fill the interface and make it look cleaner
-        new QuickMakeSpell("Tips on Stat" , "" , "SelectHeroOn" , PLACEHOLDER_STAT_TOOLTIP_SPELL , 3, 0, "", TANNERY_PLACEHOLDER_STAT_TOOLTIP),
-        new QuickMakeSpell("Tips on Hide" , "" , "SelectHeroOn" , PLACEHOLDER_HIDE_TOOLTIP_SPELL , 3, 1, "", TANNERY_PLACEHOLDER_HIDE_USAGE_TOOLTIP),
+        new QuickMakeSpell("Tips on Stat" , "" , "SelectHeroOn" , PLACEHOLDER_STAT_TOOLTIP_SPELL , 3, 0, "", TANNERY_PLACEHOLDER_STAT_TOOLTIP, "manashieldoff"),
+        new QuickMakeSpell("Tips on Hide" , "" , "SelectHeroOn" , PLACEHOLDER_HIDE_TOOLTIP_SPELL , 3, 1, "", TANNERY_PLACEHOLDER_HIDE_USAGE_TOOLTIP, "manashieldon"),
 
 
         // Buildings
         // First three aren't added to master crafter because it's useless, button position set to 0 since they're in a spellbook
-        new QuickMakeSpell("Camp Fire Kit"         , TRANSMUTE_CRAFT_BUILDING_TOOLTIP+CAMP_FIRE_KIT_RECIPE         , "Fire"                 , ABILITY_QM_CAMP_FIRE_KIT         , 0, 0, "Q", QM_BUILD_TOOLIP),
-        new QuickMakeSpell("Tent Kit"              , TRANSMUTE_CRAFT_BUILDING_TOOLTIP+TENT_KIT_RECIPE              , "Tent"                 , ABILITY_QM_TENT_KIT              , 0, 0, "W", QM_BUILD_TOOLIP),
-        new QuickMakeSpell("Troll Hut Kit"         , TRANSMUTE_CRAFT_BUILDING_TOOLTIP+TROLL_HUT_KIT_RECIPE         , "SpiritLodge"          , ABILITY_QM_TROLL_HUT_KIT         , 0, 0, "E", QM_BUILD_TOOLIP),
+        new QuickMakeSpell("Camp Fire Kit"         , TRANSMUTE_CRAFT_BUILDING_TOOLTIP+CAMP_FIRE_KIT_RECIPE         , "Fire"                 , ABILITY_QM_CAMP_FIRE_KIT         , 0, 0, "Q", QM_BUILD_TOOLIP, "resurrection"),
+        new QuickMakeSpell("Tent Kit"              , TRANSMUTE_CRAFT_BUILDING_TOOLTIP+TENT_KIT_RECIPE              , "Tent"                 , ABILITY_QM_TENT_KIT              , 0, 0, "W", QM_BUILD_TOOLIP, "battleroar"),
+        new QuickMakeSpell("Troll Hut Kit"         , TRANSMUTE_CRAFT_BUILDING_TOOLTIP+TROLL_HUT_KIT_RECIPE         , "SpiritLodge"          , ABILITY_QM_TROLL_HUT_KIT         , 0, 0, "E", QM_BUILD_TOOLIP, "spiritwolf"),
 
         // Following are also used in master crafter so they got proper button positioning
-        new QuickMakeSpell("Mud Hut Kit"           , TRANSMUTE_CRAFT_BUILDING_TOOLTIP+MUD_HUT_KIT_RECIPE           , "GoldMine"             , ABILITY_QM_MUD_HUT_KIT           , 3, 0, "R", QM_BUILD_TOOLIP),
-        new QuickMakeSpell("Forge Kit"             , TRANSMUTE_CRAFT_BUILDING_TOOLTIP+FORGE_KIT_RECIPE             , "Forge"                , ABILITY_QM_FORGE_KIT             , 0, 1, "E", QM_BUILD_TOOLIP),
-        new QuickMakeSpell("Workshop Kit"          , TRANSMUTE_CRAFT_BUILDING_TOOLTIP+WORKSHOP_KIT_RECIPE          , "TrollBurrow"          , ABILITY_QM_WORKSHOP_KIT          , 1, 1, "S", QM_BUILD_TOOLIP),
-        new QuickMakeSpell("Mixing Pot Kit"        , TRANSMUTE_CRAFT_BUILDING_TOOLTIP+MIXING_POT_KIT_RECIPE        , "SacrificialPit"       , ABILITY_QM_MIXING_POT_KIT        , 2, 1, "D", QM_BUILD_TOOLIP),
-        new QuickMakeSpell("Witch Doctors Hut Kit" , TRANSMUTE_CRAFT_BUILDING_TOOLTIP+WITCH_DOCTORS_HUT_KIT_RECIPE , "VoodooLounge"         , ABILITY_QM_WITCH_DOCTORS_HUT_KIT , 3, 1, "F", QM_BUILD_TOOLIP),
-        new QuickMakeSpell("Tannery Kit"           , TRANSMUTE_CRAFT_BUILDING_TOOLTIP+TANNERY_KIT_RECIPE           , "PigFarm"              , ABILITY_QM_TANNERY_KIT           , 0, 2, "Z", QM_BUILD_TOOLIP),
-        new QuickMakeSpell("Omnitower Kit"         , TRANSMUTE_CRAFT_BUILDING_TOOLTIP+OMNI_TOWER_KIT_RECIPE        , "OrcTower"             , ABILITY_QM_OMNI_TOWER_KIT        , 1, 2, "X", QM_BUILD_TOOLIP),
-        new QuickMakeSpell("Armory Kit"            , TRANSMUTE_CRAFT_BUILDING_TOOLTIP+ARMORY_KIT_RECIPE            , "Armory"               , ABILITY_QM_ARMORY_KIT            , 2, 2, "A", QM_BUILD_TOOLIP),
+        new QuickMakeSpell("Mud Hut Kit"           , TRANSMUTE_CRAFT_BUILDING_TOOLTIP+MUD_HUT_KIT_RECIPE           , "GoldMine"             , ABILITY_QM_MUD_HUT_KIT           , 3, 0, "R", QM_BUILD_TOOLIP, "berserk"),
+        new QuickMakeSpell("Forge Kit"             , TRANSMUTE_CRAFT_BUILDING_TOOLTIP+FORGE_KIT_RECIPE             , "Forge"                , ABILITY_QM_FORGE_KIT             , 0, 1, "E", QM_BUILD_TOOLIP, "divingeshield"),
+        new QuickMakeSpell("Workshop Kit"          , TRANSMUTE_CRAFT_BUILDING_TOOLTIP+WORKSHOP_KIT_RECIPE          , "TrollBurrow"          , ABILITY_QM_WORKSHOP_KIT          , 1, 1, "S", QM_BUILD_TOOLIP, "townbelloff"),
+        new QuickMakeSpell("Mixing Pot Kit"        , TRANSMUTE_CRAFT_BUILDING_TOOLTIP+MIXING_POT_KIT_RECIPE        , "SacrificialPit"       , ABILITY_QM_MIXING_POT_KIT        , 2, 1, "D", QM_BUILD_TOOLIP, "chemicalrage"),
+        new QuickMakeSpell("Witch Doctors Hut Kit" , TRANSMUTE_CRAFT_BUILDING_TOOLTIP+WITCH_DOCTORS_HUT_KIT_RECIPE , "VoodooLounge"         , ABILITY_QM_WITCH_DOCTORS_HUT_KIT , 3, 1, "F", QM_BUILD_TOOLIP, "creepanimatedead"),
+        new QuickMakeSpell("Tannery Kit"           , TRANSMUTE_CRAFT_BUILDING_TOOLTIP+TANNERY_KIT_RECIPE           , "PigFarm"              , ABILITY_QM_TANNERY_KIT           , 0, 2, "Z", QM_BUILD_TOOLIP, "thunderclap"),
+        new QuickMakeSpell("Omnitower Kit"         , TRANSMUTE_CRAFT_BUILDING_TOOLTIP+OMNI_TOWER_KIT_RECIPE        , "OrcTower"             , ABILITY_QM_OMNI_TOWER_KIT        , 1, 2, "X", QM_BUILD_TOOLIP, "warstomp"),
+        new QuickMakeSpell("Armory Kit"            , TRANSMUTE_CRAFT_BUILDING_TOOLTIP+ARMORY_KIT_RECIPE            , "Armory"               , ABILITY_QM_ARMORY_KIT            , 2, 2, "A", QM_BUILD_TOOLIP, "locustswarm"),
 
         // Second Buildings Page
-        new QuickMakeSpell("Teleport Beacon Kit"   , TRANSMUTE_CRAFT_BUILDING_TOOLTIP+TELEPORT_BEACON_KIT_RECIPE   , "EnergyTower"          , ABILITY_QM_TELEPORT_BEACON_KIT   , 0, 0, "E", QM_BUILD_TOOLIP),
-        new QuickMakeSpell("Hatchery Kit"          , TRANSMUTE_CRAFT_BUILDING_TOOLTIP+HATCHERY_KIT_RECIPE          , "SnowOwl"              , ABILITY_QM_HATCHERY_KIT          , 1, 0, "R", QM_BUILD_TOOLIP)
+        new QuickMakeSpell("Teleport Beacon Kit"   , TRANSMUTE_CRAFT_BUILDING_TOOLTIP+TELEPORT_BEACON_KIT_RECIPE   , "EnergyTower"          , ABILITY_QM_TELEPORT_BEACON_KIT   , 0, 0, "E", QM_BUILD_TOOLIP, "defend"),
+        new QuickMakeSpell("Hatchery Kit"          , TRANSMUTE_CRAFT_BUILDING_TOOLTIP+HATCHERY_KIT_RECIPE          , "SnowOwl"              , ABILITY_QM_HATCHERY_KIT          , 1, 0, "R", QM_BUILD_TOOLIP, "summonwareagle")
     )
 
 // Additional pages created here


### PR DESCRIPTION
Using generated orders causes problem when the target type is mismatched to the generated order. For example, generating `farsight` on a quickmake spell will break the original `farsight` for point orders, such as in the Far Sight spell.

The standard library must be adjusted to account for this and this change will have to wait until then.