### PR TITLE
Updated transformation library to handle instant order bugs.

### DIFF
--- a/wurst.build
+++ b/wurst.build
@@ -1,3 +1,4 @@
+---
 projectName: Island Troll Tribes
 dependencies:
 - https://github.com/wurstscript/wurstStdlib2
@@ -19,5 +20,3 @@ buildMapData:
       title: ' '
       subTitle: ' '
       text: ' '
-  optionsFlags:
-    hideMinimapPreview: false

--- a/wurst.build
+++ b/wurst.build
@@ -20,3 +20,5 @@ buildMapData:
       title: ' '
       subTitle: ' '
       text: ' '
+  optionsFlags:
+    hideMinimapPreview: false

--- a/wurst/lib/Transformation.wurst
+++ b/wurst/lib/Transformation.wurst
@@ -72,11 +72,9 @@ public function registerTransformation(int originID, int targetID, int abilityID
     // Output the generated ability ID for local storage.
     return abilityID
 
-
 public function registerTransformations(
         LinkedList<Pair<int, int>> transformations) returns LinkedList<int>
     return transformations.map(pair -> registerTransformation(pair.a, pair.b))
-
 
 // Performs a bulk operations for registrations. Designed to simplify what must
 // be called at runtime by external packages.

--- a/wurst/lib/Transformation.wurst
+++ b/wurst/lib/Transformation.wurst
@@ -2,20 +2,21 @@ package Transformation
 
 // Standard library imports:
 import AbilityObjEditing
+import Assets
 import LinkedList
 import ObjectIdGenerator
 import ObjectIds
+import Orders
 import MapBounds
 
 // Third-party imports:
 import Lodash
+import LodashExtensions
 import ObjectIDManager
 
 // Local imports:
 import HashingMap
 import UnitExtensions
-
-@configurable let BASE_ID = 'AZ00'
 
 // The option indicating whether proper names should be updated.
 @configurable let UPDATE_PROPER_NAME = true
@@ -34,9 +35,6 @@ public class Callbacks extends OwnedLinkedList<Pair<int, Callback>>
 let prior = new Callbacks()
 let after = new Callbacks()
 
-// Generator of ability IDs used for transformations.
-let GEN = new IdGenerator(BASE_ID)
-
 // Mapping of old and new unit IDs to the ability ID used for transforming.
 let abilities = new HashingMap<Pair<int, int>, int>(
     key -> StringHash(key.a.toString() + key.b.toString())
@@ -48,19 +46,19 @@ public function registerPriorEffect(Callback cb)
 public function registerAfterEffect(Callback cb)
     after.push(new Pair(1, cb))
 
+public function registerTransformation(int originID, int targetID) returns int
+    return registerTransformation(originID, targetID, ABIL_ID_GEN.next())
+
 // This must be called during compile time and run time for each desired pair
 // and the order of pairs for which it is called must match between the two.
-public function registerTransformation(int originID, int targetID)
+public function registerTransformation(int originID, int targetID, int abilityID) returns int
     // Construct the key used for the registration.
     let key = new Pair(originID, targetID)
 
     // Do not allow overwrites.
     if abilities.has(key)
         destroy key
-        return
-
-    // Compute the ability ID to use.
-    let abilityID = GEN.next()
+        return 0
 
     // Create the ability used for the transformation.
     if compiletime
@@ -71,6 +69,46 @@ public function registerTransformation(int originID, int targetID)
     // Register the ability.
     abilities.put(key, abilityID)
 
+    // Output the generated ability ID for local storage.
+    return abilityID
+
+
+public function registerTransformations(
+        LinkedList<Pair<int, int>> transformations) returns LinkedList<int>
+    return transformations.map(pair -> registerTransformation(pair.a, pair.b))
+
+
+// Performs a bulk operations for registrations. Designed to simplify what must
+// be called at runtime by external packages.
+function registerTransformations(
+        LinkedList<Pair<int, int>> transformations,
+        LinkedList<int> abilityIDs,
+        bool requiresFixing,
+        bool requiresAbility)
+    // Pair each tranformation with its pregenerated ability ID.
+    zip(transformations, abilityIDs).map() (element, index) ->
+        // Register the transformation.
+        registerTransformation(element.a.a, element.a.b, element.b)
+
+        // Register the fix, is required.
+        if requiresFixing
+            registerCorpseFix(element.a.a, element.a.b, requiresAbility)
+
+        // Output a dummy value, as required for mapping.
+        return 0
+
+// Simplifies the call for the above bulk operation.
+public function registerTransformations(
+        LinkedList<Pair<int, int>> transformations,
+        LinkedList<int> abilityIDs)
+    registerTransformations(transformations, abilityIDs, false, false)
+
+// Simplifies the call for the above bulk operation.
+public function registerTransformations(
+        LinkedList<Pair<int, int>> transformations,
+        LinkedList<int> abilityIDs,
+        bool requiresAbility)
+    registerTransformations(transformations, abilityIDs, true, requiresAbility)
 
 function runCallbacks(Callbacks callbacks, unit target, int unitID)
     // Consider each callback in turn.
@@ -124,6 +162,74 @@ public function transformUnit(unit origin, int targetID)
     // Destroy local resources.
     destroy key
 
+// Mapping of transformation operations that need to be fixed to whether a new ability is needed.
+let fixes = new HashingMap<Pair<int, int>, bool>(
+    key -> StringHash(key.a.toString() + key.b.toString())
+)
+
+let DUMMY_CANNIBALIZE_ID = compiletime(ABIL_ID_GEN.next())
+
+@compiletime function consumeCorpse()
+    new AbilityDefinitionCannibalize(DUMMY_CANNIBALIZE_ID)
+        ..setName("Canniablize Dummy")
+        ..setCheckDependencies(false)
+        ..presetHitPointsperSecond(lvl -> 0)
+        ..presetDurationHero(lvl -> 0)
+        ..presetDurationNormal(lvl -> 0)
+
+public function registerCorpseFix(int originID, int targetID, bool requiresAbility)
+    fixes.put(new Pair(originID, targetID), requiresAbility)
+    print(fixes.size())
+
+function fixCorpseSystem(Pair<int, int> key, unit target)
+    // Exit if this transformation does not require fixing.
+    if not fixes.has(key)
+        return
+
+    print("will fix corpses")
+
+    // Look up whether a dummy ability is required.
+    let requiresAbility = fixes.get(key)
+
+    // Add in the ability prior to the order, as necessary.
+    if requiresAbility
+        print("adding ability")
+        target.addAbility(DUMMY_CANNIBALIZE_ID)
+
+    // Create the corpse to be used.
+    let corpse = CreateCorpse(
+        players[PLAYER_NEUTRAL_AGGRESSIVE],
+        UnitIds.footman,
+        target.getX(),
+        target.getY(),
+        0
+    )
+    print("created corpses")
+
+    // Save the unit original hit points in order to reset them later.
+    let health = target.getHP()
+
+    // Ensure that the unit can attempt to consume the corpse.
+    target.setHP(1)
+
+    // Issue the order, allowing the target to default to the new corpse.
+    let rc = target.issueImmediateOrderById(Orders.cannibalize)
+    print("issued ordered: {0}".format(rc.toString()))
+
+    // Cancel the order, masking that this operation ever occurred.
+    target.issueImmediateOrderById(Orders.stop)
+
+    // Reset the health.
+    target.setHP(health)
+
+    // Remove the corpse once it is no longer needed for targeting.
+    corpse.remove()
+
+    // Remove the ability once it is no longer needed.
+    if requiresAbility
+        print("removing ability")
+        target.removeAbility(DUMMY_CANNIBALIZE_ID)
+
 init
     // Allow for this feature to be disabled.
     if UPDATE_PROPER_NAME
@@ -150,3 +256,14 @@ init
         registerAfterEffect() (unit target, int unitID) ->
             // Filter out units that do not glow.
             target.correctColor()
+
+    // Issue a cannibalize order to fix corpse targeting.
+    registerAfterEffect() (unit target, int unitID) ->
+        // Create the key for the transformation.
+        let key = new Pair(unitID, target.getTypeId())
+
+        // Forward the call to handle the actual work.
+        fixCorpseSystem(key, target)
+
+        // Clean up the local state.
+        destroy key

--- a/wurst/lib/Transformation.wurst
+++ b/wurst/lib/Transformation.wurst
@@ -74,8 +74,6 @@ public function registerTransformation(int originID, int targetID, int abilityID
 
 public function registerTransformations(
         LinkedList<Pair<int, int>> transformations) returns LinkedList<int>
-    for pair in transformations
-        print("Handling transformation {0} -> {1}".format(pair.a.asObjectName(), pair.b.asObjectName()))
     return transformations.map(pair -> registerTransformation(pair.a, pair.b))
 
 // Performs a bulk operations for registrations. Designed to simplify what must
@@ -176,21 +174,17 @@ let DUMMY_CANNIBALIZE_ID = compiletime(ABIL_ID_GEN.next())
 
 public function registerCorpseFix(int originID, int targetID, bool requiresAbility)
     fixes.put(new Pair(originID, targetID), requiresAbility)
-    print(fixes.size())
 
 function fixCorpseSystem(Pair<int, int> key, unit target)
     // Exit if this transformation does not require fixing.
     if not fixes.has(key)
         return
 
-    print("will fix corpses")
-
     // Look up whether a dummy ability is required.
     let requiresAbility = fixes.get(key)
 
     // Add in the ability prior to the order, as necessary.
     if requiresAbility
-        print("adding ability")
         target.addAbility(DUMMY_CANNIBALIZE_ID)
 
     // Create the corpse to be used.
@@ -201,7 +195,6 @@ function fixCorpseSystem(Pair<int, int> key, unit target)
         target.getY(),
         0
     )
-    print("created corpses")
 
     // Save the unit original hit points in order to reset them later.
     let health = target.getHP()
@@ -210,8 +203,12 @@ function fixCorpseSystem(Pair<int, int> key, unit target)
     target.setHP(1)
 
     // Issue the order, allowing the target to default to the new corpse.
-    let rc = target.issueImmediateOrderById(Orders.cannibalize)
-    print("issued ordered: {0}".format(rc.toString()))
+    if not target.issueImmediateOrderById(Orders.cannibalize)
+        target.getOwner().print(
+            "Failed to fix corpse targeting for {0}".format(
+                target.getName()
+            )
+        )
 
     // Cancel the order, masking that this operation ever occurred.
     target.issueImmediateOrderById(Orders.stop)
@@ -224,7 +221,6 @@ function fixCorpseSystem(Pair<int, int> key, unit target)
 
     // Remove the ability once it is no longer needed.
     if requiresAbility
-        print("removing ability")
         target.removeAbility(DUMMY_CANNIBALIZE_ID)
 
 init

--- a/wurst/lib/Transformation.wurst
+++ b/wurst/lib/Transformation.wurst
@@ -74,6 +74,8 @@ public function registerTransformation(int originID, int targetID, int abilityID
 
 public function registerTransformations(
         LinkedList<Pair<int, int>> transformations) returns LinkedList<int>
+    for pair in transformations
+        print("Handling transformation {0} -> {1}".format(pair.a.asObjectName(), pair.b.asObjectName()))
     return transformations.map(pair -> registerTransformation(pair.a, pair.b))
 
 // Performs a bulk operations for registrations. Designed to simplify what must
@@ -84,16 +86,13 @@ function registerTransformations(
         bool requiresFixing,
         bool requiresAbility)
     // Pair each tranformation with its pregenerated ability ID.
-    zip(transformations, abilityIDs).map() (element, index) ->
+    zip(transformations, abilityIDs).forEach() element ->
         // Register the transformation.
         registerTransformation(element.a.a, element.a.b, element.b)
 
         // Register the fix, is required.
         if requiresFixing
             registerCorpseFix(element.a.a, element.a.b, requiresAbility)
-
-        // Output a dummy value, as required for mapping.
-        return 0
 
 // Simplifies the call for the above bulk operation.
 public function registerTransformations(

--- a/wurst/objects/abilities/TrollUpgrade.wurst
+++ b/wurst/objects/abilities/TrollUpgrade.wurst
@@ -1,10 +1,13 @@
 package TrollUpgrade
 
 // Standard library imports:
-import ClosureTimers
 import EventHelper
 import HashMap
+import LinkedList
 import RegisterEvents
+
+// Third-party imports
+import Lodash
 
 // Local imports:
 import AutoSkill
@@ -36,57 +39,54 @@ public constant trollUpgradeMap = new HashMap<int, int>()
     ..put(ABILITY_HERB_MASTER,      UNIT_HERB_MASTER)
     ..put(ABILITY_OMNIGATHERER,     UNIT_OMNIGATHERER)
 
-// TODO: Do this while creating the classes.
-@compiletime function registerTransformations()
+let transformations = new LinkedList<Pair<int, int>>()
     // Hunter
-    registerTransformation(UNIT_HUNTER, UNIT_WARRIOR)
-    registerTransformation(UNIT_HUNTER, UNIT_TRACKER)
-    registerTransformation(UNIT_HUNTER, UNIT_JUGGERNAUT)
-    registerTransformation(UNIT_WARRIOR, UNIT_JUGGERNAUT)
-    registerTransformation(UNIT_TRACKER, UNIT_JUGGERNAUT)
-
+    ..add(new Pair(UNIT_HUNTER, UNIT_WARRIOR))
+    ..add(new Pair(UNIT_HUNTER, UNIT_TRACKER))
+    ..add(new Pair(UNIT_HUNTER, UNIT_JUGGERNAUT))
+    ..add(new Pair(UNIT_WARRIOR, UNIT_JUGGERNAUT))
+    ..add(new Pair(UNIT_TRACKER, UNIT_JUGGERNAUT))
     // Beastmaster
-    registerTransformation(UNIT_BEAST_MASTER, UNIT_SHAPESHIFTER_WOLF)
-    registerTransformation(UNIT_BEAST_MASTER, UNIT_CHICKEN_FORM)
-    registerTransformation(UNIT_BEAST_MASTER, UNIT_ULTIMATE_FORM)
-    registerTransformation(UNIT_SHAPESHIFTER_WOLF, UNIT_ULTIMATE_FORM)
-    registerTransformation(UNIT_CHICKEN_FORM, UNIT_ULTIMATE_FORM)
-
+    ..add(new Pair(UNIT_BEAST_MASTER, UNIT_SHAPESHIFTER_WOLF))
+    ..add(new Pair(UNIT_BEAST_MASTER, UNIT_CHICKEN_FORM))
+    ..add(new Pair(UNIT_BEAST_MASTER, UNIT_DRUID))
+    ..add(new Pair(UNIT_BEAST_MASTER, UNIT_ULTIMATE_FORM))
+    ..add(new Pair(UNIT_SHAPESHIFTER_WOLF, UNIT_ULTIMATE_FORM))
+    ..add(new Pair(UNIT_CHICKEN_FORM, UNIT_ULTIMATE_FORM))
+    ..add(new Pair(UNIT_DRUID, UNIT_ULTIMATE_FORM))
     // Priest
-    registerTransformation(UNIT_PRIEST, UNIT_BOOSTER)
-    registerTransformation(UNIT_PRIEST, UNIT_MASTER_HEALER)
-    registerTransformation(UNIT_PRIEST, UNIT_SAGE)
-    registerTransformation(UNIT_BOOSTER, UNIT_SAGE)
-    registerTransformation(UNIT_MASTER_HEALER, UNIT_SAGE)
-
+    ..add(new Pair(UNIT_PRIEST, UNIT_BOOSTER))
+    ..add(new Pair(UNIT_PRIEST, UNIT_MASTER_HEALER))
+    ..add(new Pair(UNIT_PRIEST, UNIT_SAGE))
+    ..add(new Pair(UNIT_BOOSTER, UNIT_SAGE))
+    ..add(new Pair(UNIT_MASTER_HEALER, UNIT_SAGE))
     // Mage
-    registerTransformation(UNIT_MAGE, UNIT_ELEMENTALIST_NEW)
-    registerTransformation(UNIT_MAGE, UNIT_HYPNOTIST)
-    registerTransformation(UNIT_MAGE, UNIT_DEMENTIA_MASTER)
-    registerTransformation(UNIT_ELEMENTALIST_NEW, UNIT_DEMENTIA_MASTER)
-    registerTransformation(UNIT_HYPNOTIST, UNIT_DEMENTIA_MASTER)
-
+    ..add(new Pair(UNIT_MAGE, UNIT_ELEMENTALIST_NEW))
+    ..add(new Pair(UNIT_MAGE, UNIT_HYPNOTIST))
+    ..add(new Pair(UNIT_MAGE, UNIT_DEMENTIA_MASTER))
+    ..add(new Pair(UNIT_ELEMENTALIST_NEW, UNIT_DEMENTIA_MASTER))
+    ..add(new Pair(UNIT_HYPNOTIST, UNIT_DEMENTIA_MASTER))
     // Scout
-    registerTransformation(UNIT_SCOUT, UNIT_TRAPPER)
-    registerTransformation(UNIT_SCOUT, UNIT_OBSERVER)
-    registerTransformation(UNIT_SCOUT, UNIT_SPY)
-    registerTransformation(UNIT_TRAPPER, UNIT_SPY)
-    registerTransformation(UNIT_OBSERVER, UNIT_SPY)
-
+    ..add(new Pair(UNIT_SCOUT, UNIT_TRAPPER))
+    ..add(new Pair(UNIT_SCOUT, UNIT_OBSERVER))
+    ..add(new Pair(UNIT_SCOUT, UNIT_SPY))
+    ..add(new Pair(UNIT_TRAPPER, UNIT_SPY))
+    ..add(new Pair(UNIT_OBSERVER, UNIT_SPY))
     // Gatherer
-    registerTransformation(UNIT_GATHERER, UNIT_RADAR_GATHERER)
-    registerTransformation(UNIT_GATHERER, UNIT_HERB_MASTER)
-    registerTransformation(UNIT_GATHERER, UNIT_OMNIGATHERER)
-    registerTransformation(UNIT_RADAR_GATHERER, UNIT_OMNIGATHERER)
-    registerTransformation(UNIT_HERB_MASTER, UNIT_OMNIGATHERER)
-
+    ..add(new Pair(UNIT_GATHERER, UNIT_RADAR_GATHERER))
+    ..add(new Pair(UNIT_GATHERER, UNIT_HERB_MASTER))
+    ..add(new Pair(UNIT_GATHERER, UNIT_OMNIGATHERER))
+    ..add(new Pair(UNIT_RADAR_GATHERER, UNIT_OMNIGATHERER))
+    ..add(new Pair(UNIT_HERB_MASTER, UNIT_OMNIGATHERER))
     // Thief
-    registerTransformation(UNIT_THIEF, UNIT_CONTORTIONIST)
-    registerTransformation(UNIT_THIEF, UNIT_ESCAPE_ARTIST)
-    registerTransformation(UNIT_THIEF, UNIT_ASSASSIN)
-    registerTransformation(UNIT_CONTORTIONIST, UNIT_ASSASSIN)
-    registerTransformation(UNIT_ESCAPE_ARTIST, UNIT_ASSASSIN)
+    ..add(new Pair(UNIT_THIEF, UNIT_CONTORTIONIST))
+    ..add(new Pair(UNIT_THIEF, UNIT_ESCAPE_ARTIST))
+    ..add(new Pair(UNIT_THIEF, UNIT_ASSASSIN))
+    ..add(new Pair(UNIT_CONTORTIONIST, UNIT_ASSASSIN))
+    ..add(new Pair(UNIT_ESCAPE_ARTIST, UNIT_ASSASSIN))
 
+// Generate the transformations during compilation.
+let transformationIDs = compiletime(registerTransformations(transformations))
 
 function upgradeUnit(unit origin, int targetID)
     // Save the statistics for the unit for restoration after level reduction.
@@ -142,4 +142,4 @@ init
         )
 
     // Register the transformations at runtime.
-    registerTransformations()
+    registerTransformations(transformations, transformationIDs, false)

--- a/wurst/objects/abilities/beastMaster/Pets/Pets.wurst
+++ b/wurst/objects/abilities/beastMaster/Pets/Pets.wurst
@@ -4,57 +4,66 @@ package Pets
 import HashMap
 import LinkedList
 
+// Third-party imports:
+import Lodash
+import LodashExtensions
+
 // Local imports:
 import LocalObjectIDs
 import Transformation
 
-// Used only to order transformation registry.
-// TODO: Order transformations globally.
-import Shapeshift
+let emptyChain = new LinkedList<int>()
 
-let growthChains = new LinkedList<LinkedList<int>>()
-    ..push(asList(
+let growthChains = new OwnedLinkedList<OwnedLinkedList<int>>()
+    ..push(asOwnedList(
         UNIT_FAWN,
         UNIT_ELK_ADOLESCENT,
         UNIT_ADULT_ELK
     ))
-    ..push(asList(
+    ..push(asOwnedList(
         UNIT_WOLF_PUP,
         UNIT_JUNGLE_WOLF,
         UNIT_ADULT_JUNGLE_WOLF
     ))
-    ..push(asList(
+    ..push(asOwnedList(
         UNIT_BEAR_CUB,
         UNIT_JUNGLE_BEAR,
         UNIT_ADULT_JUNGLE_BEAR
     ))
-    ..push(asList(
+    ..push(asOwnedList(
         UNIT_HAWK_HATCHLING,
         UNIT_HAWK_ADOLESCENT,
         UNIT_ALPHA_HAWK
     ))
-    ..push(asList(
+    ..push(asOwnedList(
         UNIT_FOREST_DRAGON_HATCHLING,
         UNIT_FOREST_DRAGON,
         UNIT_GREATER_FOREST_DRAGON
     ))
-    ..push(asList(
+    ..push(asOwnedList(
         UNIT_RED_DRAGON_HATCHLING,
         UNIT_RED_DRAGON,
         UNIT_GREATER_RED_DRAGON
     ))
-    ..push(asList(
+    ..push(asOwnedList(
         UNIT_BRONZE_DRAGON_HATCHLING,
         UNIT_BRONZE_DRAGON,
         UNIT_GREATER_BRONZE_DRAGON
     ))
-    ..push(asList(
+    ..push(asOwnedList(
         UNIT_NETHER_DRAGON_HATCHLING,
         UNIT_NETHER_DRAGON,
         UNIT_GREATER_NETHER_DRAGON
     ))
 
-let emptyChain = new LinkedList<int>()
+let transformations = zip(
+    // TODO: Use dropRight
+    growthChains.map((chain, index) -> chain.take(chain.size() - 1)).flatten(),
+    growthChains.map((chain, index) -> chain.drop(1)).flatten()
+)
+
+// Generate the transformations during compilation.
+let transformationIDs = compiletime(registerTransformations(transformations))
 
 let pets = new IterableMap<player, unit>()
 
@@ -89,12 +98,6 @@ public function group.enumPets()
         if value != null
             this.addUnit(value)
 
-// Register all abilities required for pet growth.
-@compiletime function registerTransformations()
-    for chain in growthChains
-        for i = 0 to chain.size() - 2
-            registerTransformation(chain.get(i), chain.get(i + 1))
-
 init
     // Register the transformations at runtime.
-    registerTransformations()
+    registerTransformations(transformations, transformationIDs, true)

--- a/wurst/objects/abilities/beastMaster/Shapeshift.wurst
+++ b/wurst/objects/abilities/beastMaster/Shapeshift.wurst
@@ -17,10 +17,6 @@ import LodashExtensions
 import LocalObjectIDs
 import Transformation
 
-// Used only to order transformation registry.
-// TODO: Order transformations globally.
-import Skins
-
 // The list of abilities used to transform.
 let TRANSFORMATIONS = new OwnedIterableMap<int, int>()
     ..put(ABILITY_TRANSFORM_WOLF,    UNIT_SHAPESHIFTER_WOLF)
@@ -36,17 +32,16 @@ let ABILITIES = new IterableMap<int, LinkedList<int>>()
     ..put(UNIT_SHAPESHIFTER_PANTHER, asList(ABILITY_PANTHER_PROWL))
     ..put(UNIT_SHAPESHIFTER_TIGER,   asList(ABILITY_TIGER_VICIOUS_STRIKE, 'A0GH'))
 
-let FORMS = TRANSFORMATIONS.values()
+let FORMS = TRANSFORMATIONS.values().own()
+
+let transformations = product(FORMS, FORMS)
+    .filter(t -> t.a != t.b)
+
+let transformationIDs = compiletime(registerTransformations(transformations))
 
 // The unit currently being transformed.
 // TODO: Remove this if forces support closures.
 unit originGlobal
-
-@compiletime function registerTransformations()
-    for originID in FORMS
-        for targetID in FORMS
-            if originID != targetID
-                registerTransformation(originID, targetID)
 
 // TODO: Remove logic regarding orders once a non-interrupting ability is used.
 function onCast(unit origin, int targetID)
@@ -106,7 +101,7 @@ init
             onCast(EventData.getSpellAbilityUnit(), formID)
 
     // Register the transformations at runtime.
-    registerTransformations()
+    registerTransformations(transformations, transformationIDs, false)
 
     // Undo the shapeshifting prior to other transformations.
     registerPriorEffect() (unit target, int unitID) ->

--- a/wurst/objects/abilities/beastMaster/Shapeshift.wurst
+++ b/wurst/objects/abilities/beastMaster/Shapeshift.wurst
@@ -25,7 +25,7 @@ let TRANSFORMATIONS = new OwnedIterableMap<int, int>()
     ..put(ABILITY_TRANSFORM_TIGER,   UNIT_SHAPESHIFTER_TIGER)
 
 // The unique abilities per form.
-// TODO: Automate permanency tracking for all tranformations.
+// TODO: Automate permanency tracking for all transformations.
 let ABILITIES = new IterableMap<int, LinkedList<int>>()
     ..put(UNIT_SHAPESHIFTER_WOLF,    asList(ABILITY_WOLF_HUNGER))
     ..put(UNIT_SHAPESHIFTER_BEAR,    asList(ABILITY_BEAR_BULWARK))
@@ -36,6 +36,8 @@ let FORMS = TRANSFORMATIONS.values().own()
 
 let transformations = product(FORMS, FORMS)
     .filter(t -> t.a != t.b)
+    // TODO: Figure out why the map won't compile unless this listed is owned.
+    .own()
 
 let transformationIDs = compiletime(registerTransformations(transformations))
 
@@ -109,7 +111,7 @@ init
             transformUnit(target, UNIT_SHAPESHIFTER_WOLF)
 
     // Make each unique ability permanent to preserve cooldown.
-    // TODO: Automate permanency tracking for all tranformations.
+    // TODO: Automate permanency tracking for all transformations.
     registerPriorEffect() (unit target, int unitID) ->
         if FORMS.has(target.getTypeId())
             ABILITIES.forEach() (integer formID, LinkedList<integer> abilIDs) ->
@@ -122,7 +124,7 @@ init
                         target.removeAbility(abilID)
 
     // Enable the correct ability for the unit.
-    // TODO: Automate permanency tracking for all tranformations.
+    // TODO: Automate permanency tracking for all transformations.
     // TODO: Use BlzUnitDisableAbility per unit.
     registerAfterEffect() (unit target, int unitID) ->
         if FORMS.has(target.getTypeId())

--- a/wurst/systems/commands/Skins.wurst
+++ b/wurst/systems/commands/Skins.wurst
@@ -16,10 +16,6 @@ import PlayerFeature
 import StringExtensions
 import Transformation
 
-// Used only to order transformation registry.
-// TODO: Order transformations globally.
-import TrollUpgrade
-
 let TIMEOUT = 10.0
 
 // The base message used for notifying users of the exchange.
@@ -58,6 +54,9 @@ class CustomSkin
                 transformUnit(target, unitTypeId)
 
 // This function is called externally.
+// TODO: This won't work with the new transformation registration methodology.
+//       See the associated PR for an in-depth explanation.
+//       This is not fixed part of it because skins are currently defunct.
 @compiletime function buildSkins()
     new CustomSkin(UNIT_BEAST_MASTER,  UNIT_BEAST_MASTER_1,  "skin-bm-1"     )
     new CustomSkin(UNIT_HUNTER,        UNIT_HUNTER_1,        "skin-hunter-1" )
@@ -106,8 +105,6 @@ init
         // Verify that the unit changed classes.
         if getTrollClassType(target) != getTrollClassType(unitID)
             onEnterHandler(target)
-
-
 
     PlayerFeature
         .get("WorldEdit")

--- a/wurst/systems/core/Experience.wurst
+++ b/wurst/systems/core/Experience.wurst
@@ -184,7 +184,8 @@ init
 
 
 // Verifies that the gameplay constants for hero levelling are correctly mirrored.
-@Test function testConstants()
+// TODO: Use this as @Test once unit functionality is supported.
+function testConstants()
     // Create a fresh hero unit.
     let hero = createUnit(
         players[0],

--- a/wurst/utils/LastOrder_config.wurst
+++ b/wurst/utils/LastOrder_config.wurst
@@ -1,2 +1,2 @@
 package LastOrder_config
-@config constant ORDERS_TO_HOLD = 2
+@config constant ORDERS_TO_HOLD = 4


### PR DESCRIPTION
Transforming a unit can sometimes disconnect it from the internal engine that handles the `instant` order, which is used for abilities like Raise Dead that target a single corpse. This order is responsible for choosing a nearby corpse and translating the immediate order into into a targeted order.

For unknown reasons, transforming a unit using the inverse Bear Form ability occasionally breaks Raise Dead but not Cannibalize. Furthermore, casting Cannibalize will actually correct the disconnect and allow Raise Dead to work again. This is leveraged by allowing specified transformations to include an after effect that simulates issuing a Cannibalize order in order to fix this disconnect for units that may need to cast Raise Dead or similar abilities in the future.