### PR TITLE
Fixed corpse moving system blocking autocast orders incorrectly.

### DIFF
--- a/wurst/lib/Transformation.wurst
+++ b/wurst/lib/Transformation.wurst
@@ -244,8 +244,9 @@ init
                 // Remove the temporary unit once it is no longer needed.
                 temp.remove()
 
-    // Set unit color manually, as it will default to the slow color otherwise.
+    // Allow for this feature to be disabled.
     if CORRECT_COLOR
+        // Set unit color manually, as it will default to slot color otherwise.
         registerAfterEffect() (unit target, int unitID) ->
             // Filter out units that do not glow.
             target.correctColor()

--- a/wurst/objects/abilities/MoveCorpses.wurst
+++ b/wurst/objects/abilities/MoveCorpses.wurst
@@ -301,6 +301,10 @@ function onOrder(unit target, int orderID)
     if oppositeID == 0
         return
 
+    // Exit if the order is not associated with a unit moving corpses.
+    if not target.canMoveCorpses()
+        return
+
     // Switch the abilities, as requested.
     if switchAbilities(target) != 0
         // Exit upon success, as disabling abilities includes undoing the order.


### PR DESCRIPTION
This doesn't fix any existing abilities at the time of this PR. This work is being done so that the pet updates can use an ability based on Raise Dead.