### PR TITLE
Fixed conflicting order IDs for quickmake abilities.

### DIFF
--- a/wurst/systems/crafting/QuickMakeSpell.wurst
+++ b/wurst/systems/crafting/QuickMakeSpell.wurst
@@ -344,8 +344,8 @@ function getQuickMakeSpells() returns LinkedList<QuickMakeSpell>
         // new QuickMakeSpell("Troll Hut Kit"         , TRANSMUTE_CRAFT_BUILDING_TOOLTIP+TROLL_HUT_KIT_RECIPE         , "SpiritLodge"          , ABILITY_QM_TROLL_HUT_KIT         , 0, 0, "E", QM_BUILD_TOOLIP, "spiritwolf"),
 
         // Following are also used in master crafter so they got proper button positioning
-        new QuickMakeSpell("Mud Hut Kit"           , TRANSMUTE_CRAFT_BUILDING_TOOLTIP+MUD_HUT_KIT_RECIPE           , "GoldMine"             , ABILITY_QM_MUD_HUT_KIT           , 3, 0, "R", QM_BUILD_TOOLIP, "berserk"),
-        new QuickMakeSpell("Forge Kit"             , TRANSMUTE_CRAFT_BUILDING_TOOLTIP+FORGE_KIT_RECIPE             , "Forge"                , ABILITY_QM_FORGE_KIT             , 0, 1, "E", QM_BUILD_TOOLIP, "divingeshield"),
+        new QuickMakeSpell("Mud Hut Kit"           , TRANSMUTE_CRAFT_BUILDING_TOOLTIP+MUD_HUT_KIT_RECIPE           , "GoldMine"             , ABILITY_QM_MUD_HUT_KIT           , 3, 0, "R", QM_BUILD_TOOLIP, "burrow"),
+        new QuickMakeSpell("Forge Kit"             , TRANSMUTE_CRAFT_BUILDING_TOOLTIP+FORGE_KIT_RECIPE             , "Forge"                , ABILITY_QM_FORGE_KIT             , 0, 1, "E", QM_BUILD_TOOLIP, "divineshield"),
         new QuickMakeSpell("Workshop Kit"          , TRANSMUTE_CRAFT_BUILDING_TOOLTIP+WORKSHOP_KIT_RECIPE          , "TrollBurrow"          , ABILITY_QM_WORKSHOP_KIT          , 1, 1, "S", QM_BUILD_TOOLIP, "townbelloff"),
         new QuickMakeSpell("Mixing Pot Kit"        , TRANSMUTE_CRAFT_BUILDING_TOOLTIP+MIXING_POT_KIT_RECIPE        , "SacrificialPit"       , ABILITY_QM_MIXING_POT_KIT        , 2, 1, "D", QM_BUILD_TOOLIP, "chemicalrage"),
         new QuickMakeSpell("Witch Doctors Hut Kit" , TRANSMUTE_CRAFT_BUILDING_TOOLTIP+WITCH_DOCTORS_HUT_KIT_RECIPE , "VoodooLounge"         , ABILITY_QM_WITCH_DOCTORS_HUT_KIT , 3, 1, "F", QM_BUILD_TOOLIP, "creepanimatedead"),


### PR DESCRIPTION
-Mud hut kit would trigger panic.
-Forge & Omnitower would trigger each other, there was a typo on forge orderId