### PR TITLE
Changed the model for the booster troll battle call target art

### DIFF
--- a/wurst/objects/abilities/priest/booster/TrollBattleCall.wurst
+++ b/wurst/objects/abilities/priest/booster/TrollBattleCall.wurst
@@ -25,9 +25,9 @@ let ORIGINAL_BUFF_ID = 'BHad' // Devotion Aura
 function createBuff()
     new BuffDefinition(BUFF_ID, ORIGINAL_BUFF_ID)
     ..setTargetAttachments(1, 1)
-    ..setTargetAttachmentPoint0(1, "chest")
+    ..setTargetAttachmentPoint0(1, "head")
     ..setIcon(Icons.bTNHowlOfTerror)
-    ..setArtTarget(1, Abilities.trollBeserkerTarget)
+    ..setArtTarget(1, Abilities.headhunterWEAPONSRight)
     ..setTooltipNormal(1, TOOLTIP_NORM)
     ..setTooltipNormalExtended(1, "This unit has heard a battle call, gaining damage and armor.")
 


### PR DESCRIPTION
When I rewrote this spell, I put the wrong model as a target art, put back the old one, more visible this way.