### PR TITLE
Added area of effect indicator for wards to match sight radius.

### DIFF
--- a/wurst/objects/abilities/scout/WardArea.wurst
+++ b/wurst/objects/abilities/scout/WardArea.wurst
@@ -12,6 +12,7 @@ import ColorUtils
 import LocalObjectIDs
 import ToolTipsUtils
 import StringExtensions
+import LivingClay
 
 let ABILITY_ICON = "ReplaceableTextures\\CommandButtons\\BTNGreenSentryWard.blp"
 
@@ -41,6 +42,8 @@ class WardAreaSpell extends ChannelAbilityPreset
         this.setCastRange(1, 50)
         this.setLevelSkipRequirement(0)
         this.presetTargetTypes(Targettype.POINT)
+        this.setAreaofEffect(1, SIGHT_RADIUS.toReal())
+        this.presetOption(Option.TARGETIMAGE, true)
         this.setHotkeyNormal(hotkey)
         this.setName(TOOLTIP_NORM)
         this.presetTooltipNormal(lvl -> makeToolTipNormHero(hotkey, TOOLTIP_NORM, lvl))
@@ -113,4 +116,3 @@ init
         onCast(caster)
     EventListener.onCast(ABILITY_SPY_WARD_AREA) (unit caster) ->
         onCast(caster)
-        

--- a/wurst/objects/items/LivingClay.wurst
+++ b/wurst/objects/items/LivingClay.wurst
@@ -26,7 +26,7 @@ import LocalAssets
 @configurable let CLAY_WARD_LIMIT_MAX_WARDS = 10
 
 // The sight radius of the ward, required to be the same throughout the day.
-@configurable let SIGHT_RADIUS = 700
+@configurable public let SIGHT_RADIUS = 700
 
 // The ID for the dummy unit that has the aura.
 let DUMMY_UNIT_ID = compiletime(UNIT_ID_GEN.next())

--- a/wurst/objects/items/LivingClay.wurst
+++ b/wurst/objects/items/LivingClay.wurst
@@ -141,6 +141,7 @@ let dummies = new HashMap<unit, unit>()
 @compiletime function createLivingClaySummonAbility()
     new AbilityDefinitionItemPlaceMine(PLACE_ABIL_ID)
         ..presetUnitType(lvl -> UNIT_LIVING_CLAY.toRawCode())
+        ..setAreaofEffect(1, SIGHT_RADIUS.toReal())
 
 @compiletime function createLivingClayItem()
     new ItemDefinition(ITEM_LIVING_CLAY, ItemIds.sentryWards)


### PR DESCRIPTION
$changelog: Added area of effect indicator for abilities that place wards which matches the sight radius of the ward.

A quality of life suggestion.

![](https://i.imgur.com/P6yxqeq.jpeg)