### PR TITLE
Fixed desync issue with pet movement.

### DIFF
--- a/wurst/objects/abilities/beastMaster/Pets/PetMovement.wurst
+++ b/wurst/objects/abilities/beastMaster/Pets/PetMovement.wurst
@@ -14,8 +14,6 @@ import LocalObjectIDs
 import Pets
 import Classes
 
-// Array of the mouse positions kept for moving the pet in manual control mode.
-vec2 array MOUSE_POS
 
 public enum CONTROL_MODE
     AUTO
@@ -24,8 +22,6 @@ public enum CONTROL_MODE
 // Map of players to their chosen control scheme for pets.
 public let PET_CONTROLS = new HashMap<player, CONTROL_MODE>()
 
-// Radius that pet will search for enemy when moved in manual control.
-let PET_ATTACK_RADIUS = 100.
 
 // Pet will randomly choose a position in this radius from target position in automatic mode.
 // This is done to prevent the pet and troll from stacking as well as an aesthetic choice.
@@ -39,35 +35,6 @@ let ALLOWED_ORDERS = asList(
     Orders.stop,
     Orders.holdposition
 )
-
-// Used to continuously track the mouse position of players, used to order pet in manual control mode.
-function updateMousePos()
-    MOUSE_POS[EventData.getTriggerPlayer().getId()] = EventData.getMouseWorldPos()
-
-// Manual control pet movement.
-function onKeyDown(player triggerer)
-    // Exit if the player is not using manual control mode.
-    if PET_CONTROLS.get(triggerer) == AUTO
-        return
-    
-    // Get the triggerer's Pet.
-    let pet = triggerer.getPet() 
-
-    // Find the nearest enemy in range of the target position.
-    forNearestUnit(
-        MOUSE_POS[triggerer.getId()], 
-        PET_ATTACK_RADIUS, 
-        Filter(-> GetFilterUnit().isEnemyOf(GetTriggerPlayer()))
-        ) (unit u) ->
-        // If an enemy is found.
-        if u != null and u.isEnemyOf(triggerer)
-            // Attack the enemy
-            pet.issueTargetOrderById(Orders.attack, u)
-
-        // If no enemy is found.
-        else 
-            // Move to target location.
-            pet.issuePointOrderById(Orders.smart, MOUSE_POS[triggerer.getId()])
 
 // Auto control pet movement.
 function autoMovePet()
@@ -115,14 +82,3 @@ init
         autoMovePet()
     registerPlayerUnitEvent(EVENT_PLAYER_UNIT_ISSUED_ORDER) ->
         autoMovePet()
-
-    // Continually update the mouse positions of players.
-    registerPlayerEvent(EVENT_PLAYER_MOUSE_MOVE) ->
-        updateMousePos()
-
-    // Used for manual control of the pet.
-    // Using triggers for this as it seems the events don't work.
-    let t = CreateTrigger()..addAction(-> onKeyDown(GetTriggerPlayer()))
-
-    for index = 0 to bj_MAX_PLAYER_SLOTS - 1
-        t.registerPlayerKeyPress(players[index], OSKEY_R, OSKEY_META.CTRL, true)

--- a/wurst/objects/abilities/beastMaster/Pets/PetMovement.wurst
+++ b/wurst/objects/abilities/beastMaster/Pets/PetMovement.wurst
@@ -4,7 +4,6 @@ package PetMovement
 // Standard Library Imports:
 import ClosureEvents
 import Orders
-import ClosureForGroups
 import HashMap
 import LastOrder
 import LinkedList

--- a/wurst/objects/abilities/beastMaster/Pets/PetMovementAbility.wurst
+++ b/wurst/objects/abilities/beastMaster/Pets/PetMovementAbility.wurst
@@ -23,7 +23,7 @@ let STR_MANUAL = "Manual".color(COLOR_YELLOW)
 let NAME     = "Toggle Pet Control"
 let TOOLTIP  = "Toggle pet control."
 let TOOLTIP_EXT = "Toggle between " + STR_MANUAL + " and " + STR_AUTOMATIC + " pet controls.\n\n" +
-                    STR_MANUAL + " : In manual mode press \"CTRL + R\" to order your pet to move/attack target location.\n\n" +
+                    STR_MANUAL + " : Manual mode uses regular unit controls.\n\n" +
                     STR_AUTOMATIC + " : In automatic mode the pet will copy actions taken by the owner."
 let ORDER_ID = "barkskinoff"
 

--- a/wurst/objects/abilities/beastMaster/Pets/PetMovementAbility.wurst
+++ b/wurst/objects/abilities/beastMaster/Pets/PetMovementAbility.wurst
@@ -62,30 +62,30 @@ function createTogglePetControlSpell(int newAbilId) returns ChannelAbilityPreset
         ..setTooltipNormal(1, makeToolTipNorm("F", TOOLTIP))
 
 // Used to toggle pet controls stored in `PetMovement.wurst`.
-function togglePetControl()
+function togglePetControl(player triggerer)
     // If auto controls are currently active.
-    if PET_CONTROLS.getAndRemove(EventData.getTriggerPlayer()) == AUTO
+    if PET_CONTROLS.getAndRemove(triggerer) == AUTO
         // Print message alerting the switch to manual controls.
-        print(MANUAL_CONTROL_MESSAGE)
+        printTimedToPlayer(MANUAL_CONTROL_MESSAGE, 5, triggerer)
 
         // Reset the player's controls to manual mode.
-        PET_CONTROLS.put(EventData.getTriggerPlayer(), CONTROL_MODE.MANUAL)
+        PET_CONTROLS.put(triggerer, CONTROL_MODE.MANUAL)
 
     // If manual controls are currently active.
     else
         // Print message alerting the switch to auto controls.
-        print(AUTO_CONTROL_MESSAGE)
+        printTimedToPlayer(AUTO_CONTROL_MESSAGE, 5, triggerer)
 
         // Reset the player's controls to auto mode.
-        PET_CONTROLS.put(EventData.getTriggerPlayer(), CONTROL_MODE.AUTO)
+        PET_CONTROLS.put(triggerer, CONTROL_MODE.AUTO)
 
 // Initialize all player's controls to auto at the beginning of the game.
 function initializeControls()
     Tribe.getTribes().each(t -> t.getMembers().each(member -> PET_CONTROLS.put(member, CONTROL_MODE.AUTO)))
 
 init
-    EventListener.onCast(ABILITY_TOGGLE_PET_CONTROL, _ -> togglePetControl())
-    EventListener.onCast(ABILITY_TOGGLE_PET_CONTROL_SHAPESHIFTER, _ -> togglePetControl())
+    EventListener.onCast(ABILITY_TOGGLE_PET_CONTROL, _ -> togglePetControl(EventData.getTriggerPlayer()))
+    EventListener.onCast(ABILITY_TOGGLE_PET_CONTROL_SHAPESHIFTER, _ -> togglePetControl(EventData.getTriggerPlayer()))
 
     registerGameStartEvent() ->
         nullTimer() ->

--- a/wurst/objects/abilities/beastMaster/Pets/PetMovementAbility.wurst
+++ b/wurst/objects/abilities/beastMaster/Pets/PetMovementAbility.wurst
@@ -66,7 +66,7 @@ function togglePetControl(player triggerer)
     // If auto controls are currently active.
     if PET_CONTROLS.getAndRemove(triggerer) == AUTO
         // Print message alerting the switch to manual controls.
-        printTimedToPlayer(MANUAL_CONTROL_MESSAGE, 5, triggerer)
+        triggerer.print(MANUAL_CONTROL_MESSAGE, 5)
 
         // Reset the player's controls to manual mode.
         PET_CONTROLS.put(triggerer, CONTROL_MODE.MANUAL)
@@ -74,7 +74,7 @@ function togglePetControl(player triggerer)
     // If manual controls are currently active.
     else
         // Print message alerting the switch to auto controls.
-        printTimedToPlayer(AUTO_CONTROL_MESSAGE, 5, triggerer)
+        triggerer.print(AUTO_CONTROL_MESSAGE, 5)
 
         // Reset the player's controls to auto mode.
         PET_CONTROLS.put(triggerer, CONTROL_MODE.AUTO)


### PR DESCRIPTION
$changelog: Fixed issue where some players would crash at start.

Tracking the mouse position for controlling pets was causing desyncs. So the ability to control your pet by hitting a key has been removed as there seems to be no other way to do it at the moment.