### PR TITLE
Added a message displayed on mammoth & disco duck death

### DIFF
--- a/wurst/systems/entities/bosses/DiscoDuck.wurst
+++ b/wurst/systems/entities/bosses/DiscoDuck.wurst
@@ -10,6 +10,8 @@ import LocalObjectIDs
 import ItemPoolExtensions
 import LocalSoundUtils
 import StringExtensions
+import ColorUtils
+import PingMinimap
 
 public class DiscoDuck extends Hostile
     private static let unitTypeId = UNIT_DISCO_DUCK
@@ -56,6 +58,10 @@ public class DiscoDuck extends Hostile
         let pos = getPos()
         let pinion = pinions.placeRandomItem(pos)
         pinions.removeItemType(pinion.getTypeId())
+        // TODO : Wrap this up in a Boss entity class?
+        PlaySound(Sounds.warning)
+        printTimed(("The " + getUnit().getName() + " has been killed!").color("red".toColor()), 5)
+        pingMinimap(getUnit().getPos(), 5, COLOR_YELLOW, PingMinimapStyle.ATTACK)
         super.onDeath()
 
     override function postDeath()

--- a/wurst/systems/entities/bosses/DiscoDuck.wurst
+++ b/wurst/systems/entities/bosses/DiscoDuck.wurst
@@ -10,8 +10,6 @@ import LocalObjectIDs
 import ItemPoolExtensions
 import LocalSoundUtils
 import StringExtensions
-import ColorUtils
-import PingMinimap
 
 public class DiscoDuck extends Hostile
     private static let unitTypeId = UNIT_DISCO_DUCK
@@ -58,10 +56,6 @@ public class DiscoDuck extends Hostile
         let pos = getPos()
         let pinion = pinions.placeRandomItem(pos)
         pinions.removeItemType(pinion.getTypeId())
-        // TODO : Wrap this up in a Boss entity class?
-        PlaySound(Sounds.warning)
-        printTimed(("The " + getUnit().getName() + " has been killed!").color("red".toColor()), 5)
-        pingMinimap(getUnit().getPos(), 5, COLOR_YELLOW, PingMinimapStyle.ATTACK)
         super.onDeath()
 
     override function postDeath()

--- a/wurst/systems/entities/bosses/Mammoth.wurst
+++ b/wurst/systems/entities/bosses/Mammoth.wurst
@@ -4,15 +4,11 @@ package Mammoth
 import ClosureForGroups
 import LinkedList
 import MapBounds
-import Sounds
 
 // Local imports:
 import Hostile
 import LocalObjectIDs
 import LocalAssets
-import StringExtensions
-import PingMinimap
-import ColorUtils
 
 // TODO: Allow the respawn mode to register events.
 public destructable MAMMOTH_GATE
@@ -53,10 +49,6 @@ public class Mammoth extends Hostile
         return 16
 
     override function onDeath()
-        // TODO : Wrap this up in a Boss entity class?
-        PlaySound(Sounds.warning)
-        printTimed(("The " + getUnit().getName() + " has been killed!").color("red".toColor()), 5)
-        pingMinimap(getUnit().getPos(), 5, COLOR_YELLOW, PingMinimapStyle.ATTACK)
         dead = true
         super.onDeath()
 

--- a/wurst/systems/entities/bosses/Mammoth.wurst
+++ b/wurst/systems/entities/bosses/Mammoth.wurst
@@ -4,11 +4,15 @@ package Mammoth
 import ClosureForGroups
 import LinkedList
 import MapBounds
+import Sounds
 
 // Local imports:
 import Hostile
 import LocalObjectIDs
 import LocalAssets
+import StringExtensions
+import PingMinimap
+import ColorUtils
 
 // TODO: Allow the respawn mode to register events.
 public destructable MAMMOTH_GATE
@@ -49,8 +53,13 @@ public class Mammoth extends Hostile
         return 16
 
     override function onDeath()
+        // TODO : Wrap this up in a Boss entity class?
+        PlaySound(Sounds.warning)
+        printTimed(("The " + getUnit().getName() + " has been killed!").color("red".toColor()), 5)
+        pingMinimap(getUnit().getPos(), 5, COLOR_YELLOW, PingMinimapStyle.ATTACK)
         dead = true
         super.onDeath()
+
 
     override function postDeath()
         getUnit().remove()

--- a/wurst/systems/entities/modules/Hostile.wurst
+++ b/wurst/systems/entities/modules/Hostile.wurst
@@ -2,17 +2,22 @@ package Hostile
 
 // Standard library imports:
 import ClosureTimers
-import EventHelper
 import LinkedList
+import Sounds
 
 // Local imports:
 import DummyCorpse
 import Sniff
 import UnitEntity
+import PingMinimap
+import ColorUtils
+import StringExtensions
 
 import initlater GreenFish
 import initlater Fish
 import initlater Hawk
+import initlater Mammoth
+import initlater DiscoDuck
 
 public abstract class Hostile extends UnitEntity
     construct(unit whichUnit)
@@ -61,5 +66,11 @@ public abstract class Hostile extends UnitEntity
             udg_FISH_CURRENT -= 1
         else
             udg_ANIMAL_CURRENT -= 1
+
+        if this instanceof Mammoth
+            or this instanceof DiscoDuck
+            PlaySound(Sounds.warning)
+            printTimed(("The {0} has been killed!".format(getUnit().getName())).color(COLOR_RED), 5)
+            pingMinimap(getUnit().getPos(), 5, COLOR_YELLOW, PingMinimapStyle.ATTACK)
 
         super.onDeath()

--- a/wurst/systems/entities/modules/Hostile.wurst
+++ b/wurst/systems/entities/modules/Hostile.wurst
@@ -67,8 +67,7 @@ public abstract class Hostile extends UnitEntity
         else
             udg_ANIMAL_CURRENT -= 1
 
-        if this instanceof Mammoth
-            or this instanceof DiscoDuck
+        if this instanceof Mammoth or this instanceof DiscoDuck
             PlaySound(Sounds.warning)
             printTimed(("The {0} has been killed!".format(getUnit().getName())).color(COLOR_RED), 5)
             pingMinimap(getUnit().getPos(), 5, COLOR_YELLOW, PingMinimapStyle.ATTACK)


### PR DESCRIPTION
$changelog: Mammoth & Disco Duck death now display a message to all player.

People reported that Bosses death were too important to be left unknown for the the opponent team, they requested this change.