### PR TITLE
Fixed bug where Panic would lose its effect upon item usage.

### DIFF
--- a/wurst/objects/items/Items.wurst
+++ b/wurst/objects/items/Items.wurst
@@ -103,9 +103,17 @@ public function createItemBerserkCast(int newId) returns AbilityDefinitionBerser
         ..setDurationHero(1, 0.01)
         ..setDurationNormal(1, 0.01)
         ..setCastingTime(1, 0)
-        ..setDamageTakenIncrease(1, 0)
-        ..setAttackSpeedIncrease(1, 0)
-        ..setMovementSpeedIncrease(1, 0)
         ..setBuffs(1, "")
         ..setEffectSound("")
         ..setEditorSuffix("(Wurst)")
+        // Although basing item abilities on Berserk allows immediate orders,
+        // it has the deletorious effect of overriding Berserk abilities that
+        // are already in effect. Specifically, it does not override duration
+        // but it does override the following parameters. In order to avoid
+        // interfering with Panic, the values are duplicated so the override
+        // does not mechanically impact the unit.
+        // TODO: Address the case where multiple Berserk effects could apply.
+        // TODO: Base these values directly on Panic once they are available.
+        ..setDamageTakenIncrease(1, 0.1)
+        ..setAttackSpeedIncrease(1, 0.2)
+        ..setMovementSpeedIncrease(1, 0.3)


### PR DESCRIPTION
$changelog: Fixed bug where Panic would lose its effect upon item usage.

This replaces #602 after force push was used to realign the 3.7e release.