### PR TITLE
Fixed typo in BattleTag string constants.

### DIFF
--- a/wurst/systems/commands/Skins.wurst
+++ b/wurst/systems/commands/Skins.wurst
@@ -141,23 +141,23 @@ init
             onEnterHandler(target)
 
     CustomSkin.lookup(UNIT_BOOSTER).register(
-        "Mambo#11709,",
+        "Mambo#11709",
         "MasterTroll#11111"
     )
 
     CustomSkin.lookup(UNIT_HUNTER).register(
-        "Mambo#11709,"
+        "Mambo#11709"
     )
 
     CustomSkin.lookup(UNIT_MASTER_HEALER).register(
     )
 
     CustomSkin.lookup(UNIT_MAGE).register(
-        "Mambo#11709,"
+        "Mambo#11709"
     )
 
     CustomSkin.lookup(UNIT_ELEMENTALIST_NEW).register(
-        "Mambo#11709,"
+        "Mambo#11709"
     )
 
     CustomSkin.lookup(UNIT_BEAST_MASTER).register(


### PR DESCRIPTION
This change affects a single player and is therefore omitted from the changelog.

This replaces #604 after force push was used to realign the 3.7e release.