### PR TITLE
Reverted incorrect Dream Eater logic in order to properly cancel casting.

### DIFF
--- a/wurst/objects/abilities/mage/hypnotist/DreamEater.wurst
+++ b/wurst/objects/abilities/mage/hypnotist/DreamEater.wurst
@@ -8,7 +8,6 @@ import ChannelAbilityPreset
 import Abilities
 import SimError
 
-//@configurable constant int ABILITY_ID = 'A04Z' Old GUI
 @configurable constant int BUFF_ID = BUFF_HYPNOTIZED
 
 let HP_RESTORED = 50.
@@ -27,38 +26,45 @@ let TOOLTIP_EXTENDED = ("Steals an enemy dream restoring {0} Health Point and {1
 
 let TARGET_ALLOWED = "enemies,ground,hero"
 
-class DreamEater extends ChannelAbilityPreset
-    construct(int newAbility, string hotkey, Pair<int , int> buttonPos)
-        super(newAbility, 1, true)
-        this.setName(TOOLTIP_NORM)
-        this.setHotkeyNormal(hotkey)
-        this.setCooldown(1, COOLDOWN)
-        this.setManaCost(1, MANACOST)
-        this.setIconNormal(Icons.bTNDevourMagic)
-        this.setButtonPositionNormalX(buttonPos.a)
-        this.setButtonPositionNormalY(buttonPos.b)
-        this.setTooltipNormalExtended(1, TOOLTIP_EXTENDED)
-        this.setTooltipNormal(1, makeToolTipNorm(hotkey, TOOLTIP_NORM))
-        this.setArtDuration(1, 0)
-        this.setTargetType(1, 1)
-        this.setAnimationNames(ANIMATION_NAME)
-        this.setTargetsAllowed(1, TARGET_ALLOWED)
+function constructDreamEater(
+    int newAbility,
+    string hotkey,
+    Pair<int , int> buttonPos
+) returns AbilityDefinition
+    return new ChannelAbilityPreset(newAbility, 1, true)
+        ..setName(TOOLTIP_NORM)
+        ..setHotkeyNormal(hotkey)
+        ..setCooldown(1, COOLDOWN)
+        ..setManaCost(1, MANACOST)
+        ..setIconNormal(Icons.bTNDevourMagic)
+        ..setButtonPositionNormalX(buttonPos.a)
+        ..setButtonPositionNormalY(buttonPos.b)
+        ..setTooltipNormalExtended(1, TOOLTIP_EXTENDED)
+        ..setTooltipNormal(1, makeToolTipNorm(hotkey, TOOLTIP_NORM))
+        ..setArtDuration(1, 0)
+        ..setTargetType(1, 1)
+        ..setAnimationNames(ANIMATION_NAME)
+        ..setTargetsAllowed(1, TARGET_ALLOWED)
 
-@compiletime function createDreamEater()
-    new DreamEater(ABILITY_DREAM_EATER, "W", new Pair(1, 0))
+@compiletime function createDreamEater() returns AbilityDefinition
+    return constructDreamEater(ABILITY_DREAM_EATER, "W", new Pair(1, 0))
 
 
 init
     EventListener.onTargetCast(ABILITY_DREAM_EATER) (unit caster, unit target) ->
-        if target.hasAbility(BUFF_ID)
-            flashEffect(Abilities.aIsoTarget, target, "overhead")
+        // Apply the Soul Theft visual effect.
+        flashEffect(Abilities.aIsoTarget, target, "overhead")
 
-            // Deals pure damage
-            UnitDamageTarget(caster, target, DAMAGE, false, false, ATTACK_TYPE_NORMAL, DAMAGE_TYPE_MAGIC, null)
-            target.subMana(MANA_EATEN)
+        // Damage the target.
+        UnitDamageTarget(caster, target, DAMAGE, false, false, ATTACK_TYPE_NORMAL, DAMAGE_TYPE_MAGIC, null)
+        target.subMana(MANA_EATEN)
 
-            caster.addHP(HP_RESTORED)
-            caster.addMana(MANA_RESTORED)
-        else
+        // Heal the caster.
+        caster.addHP(HP_RESTORED)
+        caster.addMana(MANA_RESTORED)
+
+    // Cancel the casting if the target is not under the effect of Hypnosis.
+    EventListener.add(EVENT_PLAYER_UNIT_SPELL_CAST) ->
+        if GetSpellAbilityId() == ABILITY_DREAM_EATER and not GetSpellTargetUnit().hasAbility(BUFF_ID)
             GetSpellAbilityUnit().abortOrder()
             simError(GetTriggerPlayer(), "Target is not Hypnotized.")


### PR DESCRIPTION
$changelog: Fixed bug where Dream Eater would enter cooldown when cast on an invalid target.

The change stemmed from which event the order was aborted during. It needs to happen during `EVENT_PLAYER_UNIT_SPELL_CAST`, not `EVENT_PLAYER_UNIT_SPELL_EFFECT`. Both `EventListener.onTargetCast` and `registerSpellEvent` are based on the latter.