### PR TITLE
Corrected scoring logic for tribe player.

### DIFF
--- a/wurst/systems/boards/PlayerScore.wurst
+++ b/wurst/systems/boards/PlayerScore.wurst
@@ -45,6 +45,7 @@ public class Score
         for tribe in tribes
             for member in tribe.getMembers()
                 playerScores.put(member, new Score(member))
+            playerScores.put(tribe.getNonMember(), new Score(tribe.getNonMember()))
 
     static function initialize()
         registerTribeInitializationFinishEvent(function createScoreMap)
@@ -159,8 +160,7 @@ init
                 let killerOwner = GetKillingUnit().getOwner()
                 let categoryName = getUnitCategory(unitKilledId)
 
-                if killerOwner != players[PLAYER_NEUTRAL_AGGRESSIVE]
-                    and killerOwner != players[PLAYER_NEUTRAL_PASSIVE]
+                if playerScores.has(killerOwner)
                     and categoryName != null
                     playerScores.get(killerOwner).addKill(categoryName)
                     scoreBoardEntries.get(categoryName).addValue(killerOwner, 1)
@@ -172,11 +172,9 @@ init
                 let target = DamageEvent.getTarget()
                 let dmgAmount = DamageEvent.getAmount()
 
-                if attackerOwner != players[PLAYER_NEUTRAL_AGGRESSIVE]
-                    and attackerOwner != players[PLAYER_NEUTRAL_PASSIVE]
+                if playerScores.has(attackerOwner)
                     and target.getOwner().isEnemyOf(attackerOwner)
                     and target.isTroll()
-                    and playerScores.has(attackerOwner)
                     playerScores.get(attackerOwner).addDamage(dmgAmount.toInt())
                     scoreBoardEntries.get("Damage Dealt")
                         .addValue(attackerOwner, dmgAmount.toInt())
@@ -190,27 +188,28 @@ init
                 let healerOwner = caster.getOwner()
                 let healingAmount = instance.getTrueAmount()
 
-                // Do not take pet healing into account, atleast for now
-                if target.isTroll()
-                    if healerOwner != target.getOwner()
-                        playerScores.get(healerOwner).addAllyHealing(healingAmount.toInt())
+                if playerScores.has(healerOwner)
+                    // Do not take pet healing into account, atleast for now
+                    if target.isTroll()
+                        if healerOwner != target.getOwner()
+                            playerScores.get(healerOwner).addAllyHealing(healingAmount.toInt())
 
-                    // Do not include self healing consumable items
-                    // I have mixed opinion on this, we should differentiate healing done from ability/item
-                    // This we can "quantify" how much cooked meat priest can actually save through healing spells
-                    // Still, I think having the healing done from meat could also be useful
-                    else if healerOwner == target.getOwner()
-                        and instance.getHealingType() != HealingType.ITEM
-                        playerScores.get(healerOwner).addSelfHealing(healingAmount.toInt())
+                        // Do not include self healing consumable items
+                        // I have mixed opinion on this, we should differentiate healing done from ability/item
+                        // This we can "quantify" how much cooked meat priest can actually save through healing spells
+                        // Still, I think having the healing done from meat could also be useful
+                        else if healerOwner == target.getOwner()
+                            and instance.getHealingType() != HealingType.ITEM
+                            playerScores.get(healerOwner).addSelfHealing(healingAmount.toInt())
 
-                    // Healing's kind of an edge case due to the string format "self/ally"
-                    let healingStr = playerScores.get(healerOwner).getHealing()
-                    scoreBoardEntries.get("Healing self/ally")
-                        .updateEntry(healerOwner.getName(), healingStr, null)
+                        // Healing's kind of an edge case due to the string format "self/ally"
+                        let healingStr = playerScores.get(healerOwner).getHealing()
+                        scoreBoardEntries.get("Healing self/ally")
+                            .updateEntry(healerOwner.getName(), healingStr, null)
 
-                    let tribeHealingStr = getTribeHealing(healerOwner)
-                    scoreBoardEntries.get("Healing self/ally")
-                        .updateTribeEntry(healerOwner, tribeHealingStr)
+                        let tribeHealingStr = getTribeHealing(healerOwner)
+                        scoreBoardEntries.get("Healing self/ally")
+                            .updateTribeEntry(healerOwner, tribeHealingStr)
 
 
             // Register cooked meat eaten amount
@@ -242,7 +241,8 @@ init
             // Register gold acquired
             EventListener.add(EVENT_PLAYER_UNIT_PAWN_ITEM) ->
                 let owner = GetTriggerUnit().getOwner()
-                playerScores.get(owner).addGold()
+                if playerScores.has(owner)
+                    playerScores.get(owner).addGold()
 
 
             // Dunno if I should let player see their score during the game, but I'll let this

--- a/wurst/systems/boards/ScoreBoard.wurst
+++ b/wurst/systems/boards/ScoreBoard.wurst
@@ -1,11 +1,14 @@
 package ScoreBoard
 
-// Standard-library imports:
+// Standard library imports:
 import HashMap
 import LinkedList
 import ClosureTimers
 import Assets
 import ClosureEvents
+
+// Third-party imports:
+import Toolkit
 
 // Local imports:
 import GameMode
@@ -18,6 +21,7 @@ import UnitExtensions
 import PlayerExtensions
 import Transformation
 import Game
+import TribeBoard
 
 let KILL_COLUMN_WIDTH = 0.055
 let STAT_LABEL_WIDTH = 0.1
@@ -94,7 +98,11 @@ public class ScoreBoardColumnEntries
         scoreBoard.updateColor(entryRow, entryColumn, color)
 
     function updateTribeEntry(player _player, int value)
-        let tribeName = _player.getTribePlayer().getName()
+        let tribePlayer = _player.getTribePlayer()
+        // Avoid duplicate counts for tribe players.
+        if tribePlayer == _player
+            return
+        let tribeName = tribePlayer.getName()
         let tribeRow = scoreBoard.getPlayerPos(tribeName)
         let currentValue = scoreBoard.getValue(tribeRow, entryColumn)
         let newValue = (currentValue.toInt() + value)
@@ -230,3 +238,22 @@ init
                     for member in tribe.getMembers()
                         scoreBoardEntries.get("Level")
                         .updateEntryIcon(member.getName(), member.getTrollIcon())
+
+    // Block this command from being used prior to the tribe board creation.
+    registerGameStartEvent() ->
+        registerToolkitCommand("scoreboard") (triggerer, arguments) ->
+            // Check the current visibility.
+            let visibility = scoreBoard.board.isDisplayed()
+
+            // Look up the tribe board for the player, which can interfere.
+            let tribeBoard = TribeBoard.findForPlayer(triggerer)
+
+            // Compute which board is currently displayed.
+            let prev = visibility ? scoreBoard.board : tribeBoard.board
+            let next = visibility ? tribeBoard.board : scoreBoard.board
+
+            // Disable the current board.
+            prev.display(triggerer, false)
+
+            // Enable the next board.
+            next.display(triggerer, true)


### PR DESCRIPTION
After recent scoring implementation changes, scores being recorded would cause a null pointer exception because `playerScores.get([tribe player])` would return `null` and then fail to record the value.

This is fixed by adding the tribe player to the `playerScores` mapping. However, this causes double counts because the API for recording values will automatically call the associated API for recording the same value for the tribe player. In order to avoid this for now, the second API call will short-circuit if the original player is the tribe player. In the long run, we should disassociate the scoreboard API entirely from the tribe concept.

Although adding the tribe player to the mapping should prevent null pointer exception, checks have also been added to make sure that the mapping had a valid entry before any further calls, just in case the player is not in the mapping. This could possibly happen during testing by manually creating units for a player not in the game.

While testing, I noticed you couldn't test the scoreboard during development mode, because the game never ends. I've added a `-scoreboard` command that will toggle visibility between the tribe board and the score board, as the engine does not support multiple multiboard displayed at once.

$changelog: Fixed bug where kills made by buildings under tribe ownership would not be handled properly.