### PR TITLE
Spawn system refactor + remove udg_current

### DIFF
--- a/wurst/systems/entities/modules/Hostile.wurst
+++ b/wurst/systems/entities/modules/Hostile.wurst
@@ -63,13 +63,6 @@ public abstract class Hostile extends UnitEntity
             doPeriodicallyCounted(ANIMATION_PERIOD, numCorpses) cb ->
                 createCorpse(pos)
 
-            if this instanceof Hawk
-                or this instanceof Fish
-                or this instanceof GreenFish
-                udg_FISH_CURRENT -= 1
-            else
-                udg_ANIMAL_CURRENT -= 1
-
         if this instanceof Mammoth or this instanceof DiscoDuck
             PlaySound(Sounds.warning)
             printTimed(("The {0} has been killed!".format(getUnit().getName())).color(COLOR_RED), 5)

--- a/wurst/systems/spawns/ResourceSpawns.wurst
+++ b/wurst/systems/spawns/ResourceSpawns.wurst
@@ -1,37 +1,76 @@
 package ResourceSpawns
 
-// Standard library imports:
-import ClosureTimers
-import ErrorHandling
 import HashMap
-import Interpolation
 import LinkedList
-import TerrainUtils
-import ClosureEvents
-
-// Third-party imports:
-import Lodash
-
-// Local imports:
-import BushSpawns
-import LocalObjectIDs
-import Game
-import GameTimer
-import GameConfig
-import GeometryUtils
 import Pool
-import LocalAssets
-import StringExtensions
-import ColorUtils
+
+import Composer
+import Lodash
+import LocalObjectIDs
+import ResourceSpawnsUtils
+import BushSpawns
+import GameConfig
+
+import ClosureEvents
+import Game
+import OnUnitEnterLeave
 import Toolkit
 
-let itemSpawnInfoMap = new IterableMap<int, SpawnInfo>()
-let animalSpawnInfoMap = new IterableMap<int, SpawnInfo>()
-let animalSpawnFunctions = new HashMap<int, VoidBiFunction<real, real>>()
-let islandSpawnList = new LinkedList<IslandSpawner>()
-let FISH_PER_AREA = 1
-var gameStartTime = 0.
+import ColorUtils
+import ClosureTimers
+import LocalAssets
+import StringExtensions
+import TerrainUtils
 
+let islandInfos = initIslandInfo()
+
+let itemSpawnInfoMap = new IterableMap<int, WeightScaler>()
+    ..put(ITEM_TINDER, new WeightScaler(450, 90, 860))
+    ..put(ITEM_CLAY_BALL, new WeightScaler(100, 185, 3600))
+    ..put(ITEM_STICK, new WeightScaler(300, 450, 360))
+    ..put(ITEM_FLINT, new WeightScaler(300, 250, 300))
+    ..put(ITEM_MANA_CRYSTAL, new WeightScaler(0, 160, 420))
+    ..put(ITEM_MUSHROOM, new WeightScaler(0, 120, 360))
+    ..put(ITEM_MAGIC, new WeightScaler(25, 25, 1))
+
+let animalSpawnInfoMap = new IterableMap<int, WeightScaler>()
+    ..put(UNIT_ELK, new WeightScaler(1000, 1000, 0))
+    ..put(UNIT_SNAKE, new WeightScaler(0, 45, 240))
+    ..put(UNIT_JUNGLE_WOLF, new WeightScaler(0, 90, 240))
+    ..put(UNIT_JUNGLE_BEAR, new WeightScaler(0, 45, 240))
+    ..put(UNIT_PANTHER, new WeightScaler(0, 45, 240))
+
+let fishSpawnInfoMap = new Pool<int>()
+    ..add(4, UNIT_HAWK)
+    ..add(2, UNIT_GREEN_FISH)
+    ..add(4, UNIT_FISH)
+
+// bookkeeper keys of spawninfos => current number of items spawned
+var currentFishes = 0
+var currentAnimals = 0
+var currentItems = 0
+
+let FISH_PER_AREA = 1
+
+let fishSpawnRects = new LinkedList<rect>()
+    ..add(gg_rct_out_1_1)
+    ..add(gg_rct_out_3_2)
+    ..add(gg_rct_out_1_2)
+    ..add(gg_rct_out_5_2)
+    ..add(gg_rct_out_2_2)
+    ..add(gg_rct_out_3_1)
+    ..add(gg_rct_out_4_1)
+    ..add(gg_rct_out_4_2)
+    ..add(gg_rct_our_5_1)
+    ..add(gg_rct_out_2_1)
+    ..add(gg_rct_fish_new_2)
+    ..add(gg_rct_fish_new_3)
+    ..add(gg_rct_fish_new_1)
+    ..add(gg_rct_fish_new_4)
+    ..add(gg_rct_fish_new_6)
+    ..add(gg_rct_fish_new_5)
+    ..add(gg_rct_fish_new_7)
+    ..add(gg_rct_fish_new_8)
 
 let spawnRegion = CreateRegion()
     ..addRect(gg_rct_spawn_area_1_1)
@@ -54,253 +93,9 @@ let restrainedSpawnRegion = CreateRegion()
     ..addRect(gg_rct_Thief_Bush_Cliff_SW_2)
     ..addRect(gg_rct_Thief_Bush_Cliff_NW)
 
-// From Marsunpaisti :
-// this class handles the spawning system trying to emulate the old code
-// so for example mana crystals at start of game can have like a 5% chance to spawn and it increases to 25% slowly
-class SpawnInfo
-    int id
-    real initialSpawnWeight
-    real finalSpawnWeight
-    real weightChangeTime
-    construct(int id, real initialSpawnWeight, real finalSpawnWeight, real weightChangeTime)
-        this.id = id
-        this.initialSpawnWeight = initialSpawnWeight
-        this.finalSpawnWeight = finalSpawnWeight
-        this.weightChangeTime = weightChangeTime
-
-    function getTimeAdjustedSpawnWeight() returns real
-        if this.weightChangeTime == 0
-            return finalSpawnWeight
-        //Clamp ratio between 0 - 1 with min & max
-        var ratio = min(1, max(0, (getElapsedGameTime() - gameStartTime) / this.weightChangeTime))
-        let spawnWeightAdjusted = linear(initialSpawnWeight, finalSpawnWeight, ratio)
-        return spawnWeightAdjusted
-
-class AnimalSpawnInfo extends SpawnInfo
-    construct(int id, real initialSpawnWeight, real finalSpawnWeight, real weightChangeTime)
-        super(id, initialSpawnWeight, finalSpawnWeight, weightChangeTime)
-        animalSpawnInfoMap.put(id, this)
-
-class ItemSpawnInfo extends SpawnInfo
-    construct(int id, real initialSpawnWeight, real finalSpawnWeight, real weightChangeTime)
-        super(id, initialSpawnWeight, finalSpawnWeight, weightChangeTime)
-        itemSpawnInfoMap.put(id, this)
-
-class IslandSpawner
-    private constant Pool<rect> spawnRegionsPool = null
-    private Pool<VoidBiFunction<real, real>> animalPool = null
-    private let spawnsPerType = new HashMap<int, int>()
-    private let referenceItemCount = new HashMap<int,real>()
-    int itemsSpawnCount
-    int animalsSpawnCount
-    private int itemsSpawnedTotal = 0
-    private Pool<int> itemPool = null
-
-    construct(int itemsSpawnCount, int animalsSpawnCount, Pool<rect> spawnRegionsPool)
-        this.itemsSpawnCount = itemsSpawnCount
-        this.animalsSpawnCount = animalsSpawnCount
-        this.spawnRegionsPool = spawnRegionsPool
-        islandSpawnList.push(this)
-
-    function randomSpawnPoint() returns vec2
-        let spawnRect = this.spawnRegionsPool.random()
-        while true
-            let spawnPoint = spawnRect.randomPoint()
-            if spawnPoint.isTerrainLand() and spawnPoint.isTerrainWalkable() and not spawnPoint.isInRegion(restrainedSpawnRegion)
-                return spawnPoint
-
-        error("ERROR: randomSpawnPoint() returned null!")
-        return vec2(0,0)
-
-    function spawnItemFromPool()
-        if this.itemPool == null
-            error("ERROR: spawnItemFromPool tried to spawn without having a generated pool!")
-            return
-
-        let spawnPoint = randomSpawnPoint()
-        let spawnItemId = itemPool.random()
-        createItem(spawnItemId, spawnPoint)
-
-        //Keep track of spawned total & spawned item type total to balance out spawning
-        this.itemsSpawnedTotal += 1
-        if not this.spawnsPerType.has(spawnItemId)
-            this.spawnsPerType.put(spawnItemId, 1)
-        else
-            this.spawnsPerType.put(spawnItemId, this.spawnsPerType.get(spawnItemId) + 1)
-
-    function spawnAnimalFromPool()
-        if this.animalPool == null
-            error("ERROR: spawnAnimalFromPool tried to spawn without having a generated pool!")
-            return
-
-        let spawnPoint = randomSpawnPoint()
-        let spawnFunc = this.animalPool.random()
-        spawnFunc.call(spawnPoint.x, spawnPoint.y)
-
-    function generateAnimalPool()
-        if this.animalPool != null
-            destroy this.animalPool
-
-        this.animalPool = new Pool<VoidBiFunction<real, real>>
-        for id in animalSpawnInfoMap
-            let spawnInfo = animalSpawnInfoMap.get(id)
-            this.animalPool.add((spawnInfo.getTimeAdjustedSpawnWeight() * gameConfig.getHostileSpawnRate()).ceil(), animalSpawnFunctions.get(id))
-
-    function generateItemPool()
-        /*
-        This function generates an island-specific itempool with adjusted weights according to how much current state of spawned items
-        differs from what the adjusted weights are.
-
-        For example, if there is less flints than the amount of flints that the spawn ratios try to aim for, we increase flint spawns by up to 50% depending on how much behind the spawns are
-        */
-        if this.itemPool != null
-            destroy this.itemPool
-
-        this.itemPool = new Pool<int>()
-        var totalWeight = 0.
-        for i in itemSpawnInfoMap
-            totalWeight += itemSpawnInfoMap.get(i).getTimeAdjustedSpawnWeight()
-
-        for itm in itemSpawnInfoMap
-            // From Marsunpaisti :
-            // this part is where I calculate how many items have actually spawned and how many "should" have spawned
-            // basically it means if difference from desired amount is 50% too much -> it will multiply spawn rate by 0.8 to reduce chance
-            // so if rocks have 20% rate to spawn, and you have 150 rocks when you should have 100, it adjusts it to 20% * 0.8 = 16% chance to spawn rocks
-            // to debug you can print for each islandSpawner the contents of
-            // private let spawnsPerType = new HashMap<int, int>()
-            // private let referenceItemCount = new HashMap<int,real>()
-            // spawnPerType contains how many items with ID have been spawned to the island
-            // referenceitemcount contains how many the system thinks "should" have been spawned
-            // and to see the current spawn rates you need to look at pool class
-            // in wurst/lib/Pool.wurst
-            // You gotta print the itemPool item weight / itemPool totalweight
-            // The pool is basically a weighted random selection pool class
-            // so if I put in A with weight 1 and B with weight 1 and C with weight 2
-            // I would have 25% chance to get A, 25% chance to get B and 50% chance to get C
-            // maybe you could add a function to Pool that returns the % chance of getting something
-
-            // Get adjusted spawn weights based on desired item counts from previous spawning round
-            let spawnInfo = itemSpawnInfoMap.get(itm)
-            let itemWeight = spawnInfo.getTimeAdjustedSpawnWeight()
-            var adjustmentRatio = 1.
-
-            if referenceItemCount.has(spawnInfo.id) and spawnsPerType.has(spawnInfo.id)
-                let desiredAmount = referenceItemCount.get(spawnInfo.id)
-                let currentAmount = this.spawnsPerType.get(spawnInfo.id)
-                if desiredAmount != 0 and currentAmount != 0
-                    let itemRatio = currentAmount / desiredAmount
-                    let difference = itemRatio - 1
-                    if difference > 0
-                        adjustmentRatio = linear(1, 1.2, min(1, (difference.abs() / 0.5)))
-                    else
-                        adjustmentRatio = linear(1, 0.8, min(1, (difference.abs() / 0.5)))
-
-            this.itemPool.add((itemWeight * adjustmentRatio).round(), spawnInfo.id)
-
-            //Update desired item counts for next spawning round
-            //Basically keeping count of the sum that the total items of that type should be at on average at the end of this spawn cycle
-            let weightRatio = itemWeight / totalWeight
-            let itemTotalThisRound = (this.itemsSpawnCount * udg_ITEM_BASE).ceil()
-            if referenceItemCount.has(spawnInfo.id)
-                referenceItemCount.put(spawnInfo.id, referenceItemCount.get(spawnInfo.id) + (itemTotalThisRound * weightRatio))
-            else
-                referenceItemCount.put(spawnInfo.id, (itemTotalThisRound * weightRatio))
-
-    ondestroy
-        if this.spawnRegionsPool != null
-            destroy this.spawnRegionsPool
-        destroy this.spawnsPerType
-        destroy this.referenceItemCount
-        destroy this.animalPool
-        destroy this.itemPool
-
-public function lowerItem(int count)
-    udg_ITEM_CURRENT -= count
-
-public function handleItemSpawning()
-    for island in islandSpawnList
-        island.generateItemPool()
-
-    let spawnedCount = new IterableMap<IslandSpawner, int>()
-
-    //Use animation period * 2 since the old system was WAY slower than this
-    doPeriodically(ANIMATION_PERIOD*2) itemLoop ->
-        //Spawn one item on each island until they all reached the max count
-        bool loopDidSpawn = false
-        for island in islandSpawnList
-            //Abruptly stop loop if item limit reached
-            if udg_ITEM_CURRENT >= udg_ITEM_MAX
-                loopDidSpawn = false
-                break
-
-            //Spawn item if island-specific spawn count is not yet achieved
-            if not spawnedCount.has(island) or (spawnedCount.get(island) < (island.itemsSpawnCount * udg_ITEM_BASE).ceil())
-                island.spawnItemFromPool()
-                udg_ITEM_CURRENT += 1
-                spawnedCount.put(island, spawnedCount.get(island) + 1)
-                loopDidSpawn = true
-
-        //Return when all islandSpawners iterated without any spawns (or abrupt stop condition reached)
-        if not loopDidSpawn
-            destroy spawnedCount
-            destroy itemLoop //Break
-
-
-public function handleAnimalSpawning()
-    for island in islandSpawnList
-        island.generateAnimalPool()
-
-    let spawnedCount = new HashMap<IslandSpawner, int>()
-
-    //Use animation period * 2 since the old system was WAY slower than this
-    doPeriodically(ANIMATION_PERIOD*2) animalLoop ->
-        //Spawn one animal on each island until they all reached the max count
-        bool loopDidSpawn = false
-        for island in islandSpawnList
-            //Abruptly stop loop if animal limit reached
-            if (udg_ANIMAL_CURRENT >= gameConfig.getMaxAnimals())
-                loopDidSpawn = false
-                break
-
-            //Spawn item if island-specific spawn count is not yet achieved
-            if not spawnedCount.has(island) or (spawnedCount.get(island) < (island.animalsSpawnCount * udg_FOOD_BASE).ceil())
-                island.spawnAnimalFromPool()
-                udg_ANIMAL_CURRENT += 1
-                spawnedCount.put(island, spawnedCount.get(island) + 1)
-                loopDidSpawn = true
-
-        //Return when all islandSpawners iterated without any spawns (or abrupt stop condition reached)
-        if not loopDidSpawn
-            destroy spawnedCount
-            destroy animalLoop //Break
-
-function initItemSpawnInfo()
-    new ItemSpawnInfo(ITEM_TINDER, 450, 90, 860)
-    new ItemSpawnInfo(ITEM_CLAY_BALL, 100, 185, 360)
-    new ItemSpawnInfo(ITEM_STICK, 300, 450, 360)
-    new ItemSpawnInfo(ITEM_FLINT, 300, 250, 300)
-    new ItemSpawnInfo(ITEM_MANA_CRYSTAL, 0, 160, 420)
-    new ItemSpawnInfo(ITEM_STONE, 110, 280, 560)
-    new ItemSpawnInfo(ITEM_MUSHROOM, 0, 120, 360)
-    new ItemSpawnInfo(ITEM_MAGIC, 25, 25, 1)
-
-function initAnimalSpawnInfo()
-    new AnimalSpawnInfo(UNIT_ELK, 1000, 1000, 0)
-    new AnimalSpawnInfo(UNIT_SNAKE, 0, 45, 240)
-    new AnimalSpawnInfo(UNIT_JUNGLE_WOLF, 0, 90, 240)
-    new AnimalSpawnInfo(UNIT_JUNGLE_BEAR, 0, 45, 240)
-    new AnimalSpawnInfo(UNIT_PANTHER, 0, 45, 240)
-
-    animalSpawnFunctions.put(UNIT_ELK) (x, y) ->
-        createUnit(players[PLAYER_NEUTRAL_AGGRESSIVE], UNIT_ELK, vec2(x, y), randomAngle())
-    animalSpawnFunctions.put(UNIT_SNAKE) (x, y) ->
-        createUnit(players[PLAYER_NEUTRAL_AGGRESSIVE], UNIT_SNAKE, vec2(x, y), randomAngle())
-    animalSpawnFunctions.put(UNIT_JUNGLE_WOLF) (x, y) ->
-        createUnit(players[PLAYER_NEUTRAL_AGGRESSIVE], UNIT_JUNGLE_WOLF, vec2(x, y), randomAngle())
-    animalSpawnFunctions.put(UNIT_JUNGLE_BEAR) (x, y) ->
-        createUnit(players[PLAYER_NEUTRAL_AGGRESSIVE], UNIT_JUNGLE_BEAR, vec2(x, y), randomAngle())
-    animalSpawnFunctions.put(UNIT_PANTHER) (x, y) ->
-        createUnit(players[PLAYER_NEUTRAL_AGGRESSIVE], UNIT_PANTHER, vec2(x, y), randomAngle())
+let animalSpawner = initAnimalSpawner()
+let itemSpawner = initItemSpawner()
+let fishSpawner = initFishSpawner()
 
 // From Marsunpaisti :
 // this is the part that handles the island balance
@@ -308,117 +103,158 @@ function initAnimalSpawnInfo()
 // so all areas get picked evenly
 // new IslandSpawner(23, 6, swSpawns) here the variables mean this island will get 23 items and 6 animals
 // because SW is bigger than the others
-function initIslandSpawners()
-    let nwSpawns = new Pool<rect>()
-    nwSpawns.add(65, gg_rct_spawn_area_1_1)
-    nwSpawns.add(22, gg_rct_spawn_area_1_2)
-    nwSpawns.add(13, gg_rct_spawn_area_1_3)
-    new IslandSpawner(15, 4, nwSpawns)
+function initIslandInfo() returns LinkedList<IslandInfo>
+    return new LinkedList<IslandInfo>
+        ..add(new IslandInfo(15, 4, new Pool<rect>()
+            ..add(65, gg_rct_spawn_area_1_1)
+            ..add(22, gg_rct_spawn_area_1_2)
+            ..add(13, gg_rct_spawn_area_1_3))
+        )
+        ..add(new IslandInfo(16, 4, new Pool<rect>()
+            ..add(66, gg_rct_spawn_area_2_1)
+            ..add(16, gg_rct_spawn_area_2_2)
+            ..add(18, gg_rct_spawn_area_2_3))
+        )
+        ..add(new IslandInfo(16, 4, new Pool<rect>()
+            ..add(54, gg_rct_spawn_area_3_1)
+            ..add(13, gg_rct_spawn_area_3_2)
+            ..add(33, gg_rct_spawn_area_3_3))
+        )
+        ..add(new IslandInfo(23, 6, new Pool<rect>()
+            ..add(88, gg_rct_spawn_area_4_1)
+            ..add(7, gg_rct_spawn_area_4_2)
+            ..add(8, gg_rct_spawn_area_4_3))
+        )
 
-    let neSpawns = new Pool<rect>()
-    neSpawns.add(66, gg_rct_spawn_area_2_1)
-    neSpawns.add(16, gg_rct_spawn_area_2_2)
-    neSpawns.add(18, gg_rct_spawn_area_2_3)
-    new IslandSpawner(16, 4, neSpawns)
+function initFishSpawner() returns Spawner
+    let fishSpawners = new LinkedList<Composer>()
+    for r in fishSpawnRects
+        fishSpawners.add(new FishSpawnComposer(fishSpawnInfoMap, r))
+    
+    return new Spawner(
+        new StaggeredComposer(
+            FISH_PER_AREA,
+            new MultipleComposer(fishSpawners)
+        )
+    )
 
-    let seSpawns = new Pool<rect>()
-    seSpawns.add(54, gg_rct_spawn_area_3_1)
-    seSpawns.add(13, gg_rct_spawn_area_3_2)
-    seSpawns.add(33, gg_rct_spawn_area_3_3)
-    new IslandSpawner(16, 4, seSpawns)
+function initItemSpawner() returns Spawner
+    let itemPools = new LinkedList<ItemPool>()
+    EmptyFunction<bool> condition = () ->
+        let b = currentItems < gameConfig.getItemMax()
+        if b
+            currentItems++ // Bookkeeping
+        return b
+    
+    // Make one spawner per island and combine at the end
+    let islandSpawners = new LinkedList<Composer>()
+    for island in islandInfos
+        let itemPool = new ItemPool(itemSpawnInfoMap, island.itemsSpawnCount)
+        itemPools.add(itemPool)
+        islandSpawners.add(
+            new StaggeredComposer(
+                (island.itemsSpawnCount * gameConfig.getItemBase()).ceil(),
+                new ConditionalComposer(
+                    condition,
+                    new ItemSpawnComposer(itemPool, island.spawnRegionsPool, restrainedSpawnRegion)
+                )
+            )
+        )
 
-    let swSpawns = new Pool<rect>()
-    swSpawns.add(88, gg_rct_spawn_area_4_1)
-    swSpawns.add(7, gg_rct_spawn_area_4_2)
-    swSpawns.add(8, gg_rct_spawn_area_4_3)
-    new IslandSpawner(23, 6, swSpawns)
+    // Update the pools before each execution
+    EmptyFunction<bool> preAction = () ->
+        for itemPool in itemPools
+            itemPool.update()
+        return true
+    
+    return new Spawner(
+        new ConditionalComposer(
+            preAction,
+            new MultipleComposer(islandSpawners)
+        )
+    )
 
-function startSpawnCycle()
+function initAnimalSpawner() returns Spawner
+    let weightedPools = new LinkedList<WeightedPool<int>>()
+    EmptyFunction<bool> condition = () -> (currentAnimals < gameConfig.getMaxAnimals())
+
+    // Make one spawner per island and combine at the end
+    let islandSpawners = new LinkedList<Composer>()
+    for island in islandInfos
+        let weightedPool = new WeightedPool(animalSpawnInfoMap)
+        weightedPools.add(weightedPool)
+        islandSpawners.add(
+            new StaggeredComposer(
+                (island.animalsSpawnCount * gameConfig.getFoodBase()).ceil(),
+                new ConditionalComposer(
+                    condition,
+                    new AnimalSpawnComposer(weightedPool, island.spawnRegionsPool, restrainedSpawnRegion)
+                )
+            )
+        )
+
+    // Update the pools before each execution
+    EmptyFunction<bool> preAction = () ->
+        for weightedPool in weightedPools
+            weightedPool.update()
+        return true
+        
+    return new Spawner(
+        new ConditionalComposer(
+            preAction,
+            new MultipleComposer(islandSpawners)
+        )
+    )
+
+// Bookkeeping
+public function lowerItem(int count)
+    currentItems -= count
+
+function bookkeep(bool born, unit u)
+    if animalSpawnInfoMap.has(u.getTypeId())
+        currentAnimals = born ? (currentAnimals + 1) : (currentAnimals - 1)
+    
+    if fishSpawnInfoMap.options.has(u.getTypeId())
+        currentFishes = born ? (currentFishes + 1) : (currentFishes - 1)
+
+// Spawn cycles
+function adjustBaseSpawnrates()
+    //Replacement for modStats function of the legacy system.
+    //Dynamically adjust overall item & animal amounts (and specific item type amounts but thats handles by spawnInfo classes now)
+    gameConfig.setItemBase(max(.15,gameConfig.getItemBase()-0.2))
+    gameConfig.setFoodBase(max(.15,gameConfig.getFoodBase()-0.3))
+
+function startSpawnCycle(Spawner animalSpawner, Spawner itemSpawner, Spawner fishSpawner)
     doPeriodically(120) spawnerCallback ->
-        handleAnimalSpawning()
+        animalSpawner.spawn()
         doAfter(5) ->
-            handleItemSpawning()
+            itemSpawner.spawn()
             adjustBaseSpawnrates()
 
     //Another loop because 1 spawned fish per area per 240 seconds is hard to cut in half
     doPeriodically(240) fishHawkCallback ->
         //Delays so these dont happen exactly at the same time as the 120 second interval actions
         doAfter(10, -> addItemsToBushes())
-        doAfter(15, -> spawnFishAndHawks())
-
-function adjustBaseSpawnrates()
-    //Replacement for modStats function of the legacy system.
-    //Dynamically adjust overall item & animal amounts (and specific item type amounts but thats handles by spawnInfo classes now)
-    udg_ITEM_BASE = max(.15,udg_ITEM_BASE-0.2)
-    udg_FOOD_BASE = max(.15,udg_FOOD_BASE-0.3)
-
-function spawnFishOrHawk(rect spawnRect)
-    // Exit if the spawn limit has been reached.
-    if udg_ITEM_LIMIT_MODE and udg_FISH_CURRENT >= udg_FISH_MAX
-        return
-
-    // Randomly choose the location to spawn the new unit.
-    let spawnPoint = spawnRect.randomPoint()
-
-    // Randomly choose a type of unit to spawn.
-    // TODO: Use a pool object to choose randomly.
-    let rand = GetRandomInt(1, 13)
-    let targetID = rand <= 4
-        ? UNIT_HAWK
-        : (rand <= 6 ? UNIT_GREEN_FISH : UNIT_FISH)
-
-    // Increment the counter tracking the total number of river-based animals.
-    udg_FISH_CURRENT += 1
-
-    // Spawn a unit of the selected type.
-    createUnit(
-        players[PLAYER_NEUTRAL_AGGRESSIVE],
-        targetID,
-        spawnPoint,
-        randomAngle()
-    )
-
-function spawnFishAndHawks()
-    doPeriodicallyCounted(ANIMATION_PERIOD * 2, FISH_PER_AREA) fishHawkLoop ->
-        spawnFishOrHawk(gg_rct_out_1_1)
-        spawnFishOrHawk(gg_rct_out_3_2)
-        spawnFishOrHawk(gg_rct_out_1_2)
-        spawnFishOrHawk(gg_rct_out_5_2)
-        spawnFishOrHawk(gg_rct_out_2_2)
-        spawnFishOrHawk(gg_rct_out_3_1)
-        spawnFishOrHawk(gg_rct_out_4_1)
-        spawnFishOrHawk(gg_rct_out_4_2)
-        spawnFishOrHawk(gg_rct_our_5_1)
-        spawnFishOrHawk(gg_rct_out_2_1)
-        spawnFishOrHawk(gg_rct_fish_new_2)
-        spawnFishOrHawk(gg_rct_fish_new_3)
-        spawnFishOrHawk(gg_rct_fish_new_1)
-        spawnFishOrHawk(gg_rct_fish_new_4)
-        spawnFishOrHawk(gg_rct_fish_new_6)
-        spawnFishOrHawk(gg_rct_fish_new_5)
-        spawnFishOrHawk(gg_rct_fish_new_7)
-        spawnFishOrHawk(gg_rct_fish_new_8)
+        doAfter(15, -> fishSpawner.spawn())
 
 bool array debug_status
 
 init
-    initItemSpawnInfo()
-    initAnimalSpawnInfo()
-    initIslandSpawners()
-
     registerGameStartEvent() ->
-        gameStartTime = getElapsedGameTime()
-
         //First spawns. Do twice to retain original amounts after halving the items per spawn and doubling cycle frequency.
-        handleAnimalSpawning()
-        doAfter(5, -> handleAnimalSpawning())
-        doAfter(10, -> handleAnimalSpawning())
-        doAfter(15, -> handleItemSpawning())
-        doAfter(20, -> handleItemSpawning())
-        doAfter(25, -> spawnFishAndHawks())
+        animalSpawner.spawn()
+        doAfter(5, -> animalSpawner.spawn())
+        doAfter(10, -> animalSpawner.spawn())
+        doAfter(15, -> itemSpawner.spawn())
+        doAfter(20, -> itemSpawner.spawn())
+        doAfter(25, -> fishSpawner.spawn())
         doAfter(30, -> addItemsToBushes())
-        startSpawnCycle()
+        startSpawnCycle(animalSpawner, itemSpawner, fishSpawner)
 
+    // Keep track of animals/fishes
+    onLeave(() -> bookkeep(false, getEnterLeaveUnit()))
+    onEnter(() -> bookkeep(true, getEnterLeaveUnit()))
+    
     // SP for spawning point, Debugging which spot can spawn items
     registerToolkitCommand("sp") (triggerPlayer, arguments) ->
         // Look up the index for the triggering player.

--- a/wurst/systems/spawns/ResourceSpawns.wurst
+++ b/wurst/systems/spawns/ResourceSpawns.wurst
@@ -218,11 +218,12 @@ public function lowerItem(int count)
     currentItems -= count
 
 function bookkeep(bool born, unit u)
-    if animalSpawnInfoMap.has(u.getTypeId())
-        currentAnimals = born ? (currentAnimals + 1) : (currentAnimals - 1)
-    
-    if fishSpawnInfoMap.options.has(u.getTypeId())
-        currentFishes = born ? (currentFishes + 1) : (currentFishes - 1)
+    if u.getOwner() == players[PLAYER_NEUTRAL_AGGRESSIVE]
+        if animalSpawnInfoMap.has(u.getTypeId())
+            currentAnimals = born ? (currentAnimals + 1) : (currentAnimals - 1)
+        
+        if fishSpawnInfoMap.options.has(u.getTypeId())
+            currentFishes = born ? (currentFishes + 1) : (currentFishes - 1)
 
 // Spawn cycles
 function adjustBaseSpawnrates()

--- a/wurst/systems/spawns/ResourceSpawns.wurst
+++ b/wurst/systems/spawns/ResourceSpawns.wurst
@@ -127,9 +127,16 @@ function initIslandInfo() returns LinkedList<IslandInfo>
         )
 
 function initFishSpawner() returns Spawner
+    EmptyFunction<bool> condition = () -> currentFishes < gameConfig.getFishMax()
+
     let fishSpawners = new LinkedList<Composer>()
     for r in fishSpawnRects
-        fishSpawners.add(new FishSpawnComposer(fishSpawnInfoMap, r))
+        fishSpawners.add(
+            new ConditionalComposer(
+                condition,
+                new FishSpawnComposer(fishSpawnInfoMap, r)
+            )
+        )
     
     return new Spawner(
         new StaggeredComposer(

--- a/wurst/systems/spawns/ResourceSpawns.wurst
+++ b/wurst/systems/spawns/ResourceSpawns.wurst
@@ -261,6 +261,13 @@ init
     // Keep track of animals/fishes
     onLeave(() -> bookkeep(false, getEnterLeaveUnit()))
     onEnter(() -> bookkeep(true, getEnterLeaveUnit()))
+
+    registerToolkitCommand("sbk") (triggerPlayer, arguments) ->
+        printTimedToPlayer("There are currently {0} animals, {1} fishes/hawks and {2} items in game".format(
+            currentAnimals.toString(),
+            currentFishes.toString(),
+            currentItems.toString()
+        ).color(GENERAL_COLOR), 10, triggerPlayer)
     
     // SP for spawning point, Debugging which spot can spawn items
     registerToolkitCommand("sp") (triggerPlayer, arguments) ->

--- a/wurst/systems/spawns/ResourceSpawnsUtils.wurst
+++ b/wurst/systems/spawns/ResourceSpawnsUtils.wurst
@@ -1,0 +1,201 @@
+package ResourceSpawnsUtils
+
+import Composer
+
+// Standard library imports:
+import HashMap
+import Interpolation
+import TerrainUtils
+
+// Local imports:
+import Game
+import GameTimer
+import GameConfig
+import GeometryUtils
+import Pool
+
+function getRandomAllowedPoint(Pool<rect> allowedRegions, region restrainedSpawnRegion) returns vec2
+    let spawnRect = allowedRegions.random()
+
+    while true
+        let spawnPoint = spawnRect.randomPoint()
+        if spawnPoint.isTerrainLand() and spawnPoint.isTerrainWalkable() and not spawnPoint.isInRegion(restrainedSpawnRegion)
+            return spawnPoint
+    
+    return vec2(0,0)
+
+public class Spawner
+    Composer fn
+    
+    construct(Composer fn)
+        this.fn = fn
+    
+    function spawn()
+        this.fn.execute()
+
+public class ItemSpawnComposer implements Composer
+    protected ItemPool items
+    protected Pool<rect> allowedRegions
+    protected region disallowedRegions
+
+    construct(ItemPool items, Pool<rect> allowedRegions, region disallowedRegions)
+        this.items = items
+        this.allowedRegions = allowedRegions
+        this.disallowedRegions = disallowedRegions
+    
+    override function execute()
+        let spawnPoint = getRandomAllowedPoint(this.allowedRegions, this.disallowedRegions)
+        let spawnItemId = this.items.random()
+        createItem(spawnItemId, spawnPoint)
+
+        if not this.items.spawnsPerType.has(spawnItemId)
+            this.items.spawnsPerType.put(spawnItemId, 1)
+        else
+            this.items.spawnsPerType.put(spawnItemId, this.items.spawnsPerType.get(spawnItemId) + 1)
+
+public class FishSpawnComposer implements Composer
+    protected Pool<int> units
+    protected rect allowedRegion
+
+    construct(Pool<int> units, rect allowedRegion)
+        this.units = units
+        this.allowedRegion = allowedRegion
+    
+    override function execute()
+        // Exit if the spawn limit has been reached.
+        if udg_FISH_CURRENT >= gameConfig.getFishMax()
+            return
+        
+        let spawnPoint = this.allowedRegion.randomPoint()
+        let targetID = this.units.random()
+    
+        // Spawn a unit of the selected type.
+        createUnit(
+            players[PLAYER_NEUTRAL_AGGRESSIVE],
+            targetID,
+            spawnPoint,
+            randomAngle()
+        )
+
+public class AnimalSpawnComposer implements Composer
+    protected Pool<int> units
+    protected Pool<rect> allowedRegions
+    protected region disallowedRegions
+
+    construct(Pool<int> units, Pool<rect> allowedRegions, region disallowedRegions)
+        this.allowedRegions = allowedRegions
+        this.disallowedRegions = disallowedRegions
+        this.units = units
+    
+    override function execute()
+        let spawnPoint = getRandomAllowedPoint(this.allowedRegions, this.disallowedRegions)
+        let animal = this.units.random()
+        createUnit(players[PLAYER_NEUTRAL_AGGRESSIVE], animal, spawnPoint, randomAngle())
+
+public class IslandInfo
+    int itemsSpawnCount
+    int animalsSpawnCount
+    Pool<rect> spawnRegionsPool
+    
+    construct(int itemsSpawnCount, int animalsSpawnCount, Pool<rect> spawnRegionsPool)
+        this.itemsSpawnCount = itemsSpawnCount
+        this.animalsSpawnCount = animalsSpawnCount
+        this.spawnRegionsPool = spawnRegionsPool
+
+// From Marsunpaisti :
+// this class handles the spawning system trying to emulate the old code
+// so for example mana crystals at start of game can have like a 5% chance to spawn and it increases to 25% slowly
+public class WeightScaler
+    real initialSpawnWeight
+    real finalSpawnWeight
+    real weightChangeTime
+    construct(real initialSpawnWeight, real finalSpawnWeight, real weightChangeTime)
+        this.initialSpawnWeight = initialSpawnWeight
+        this.finalSpawnWeight = finalSpawnWeight
+        this.weightChangeTime = weightChangeTime
+
+    function getTimeAdjustedSpawnWeight() returns real
+        if this.weightChangeTime == 0
+            return finalSpawnWeight
+        //Clamp ratio between 0 - 1 with min & max
+        let ratio = min(1, max(0, (getElapsedGameTime() - GAME_TIMER.getElapsed()) / this.weightChangeTime))
+        let spawnWeightAdjusted = linear(initialSpawnWeight, finalSpawnWeight, ratio)
+        return spawnWeightAdjusted
+        
+public class WeightedPool<V> extends Pool<V>
+    protected IterableMap<V, WeightScaler> weightMap
+
+    construct(IterableMap<V, WeightScaler> weightMap)
+        this.weightMap = weightMap
+
+    function update()
+        this.totalWeight = 0
+        this.options.flush()
+        
+        for key in this.weightMap
+            let weightScaler = this.weightMap.get(key)
+            this.add((weightScaler.getTimeAdjustedSpawnWeight() * gameConfig.getHostileSpawnRate()).ceil(), key)
+
+public class ItemPool extends Pool<int>
+    protected IterableMap<int, WeightScaler> weightMap
+    let referenceItemCount = new HashMap<int,real>()
+    let spawnsPerType = new HashMap<int, int>()
+    int itemsSpawnCount
+
+    construct(IterableMap<int, WeightScaler> weightMap, int itemsSpawnCount)
+        this.weightMap = weightMap
+        this.itemsSpawnCount = itemsSpawnCount
+
+    function update()
+        this.totalWeight = 0
+        this.options.flush()
+        
+        var totalWeight = 0.
+        
+        for i in this.weightMap
+            totalWeight += this.weightMap.get(i).getTimeAdjustedSpawnWeight()
+
+        for id in this.weightMap
+            // From Marsunpaisti :
+            // this part is where I calculate how many items have actually spawned and how many "should" have spawned
+            // basically it means if difference from desired amount is 50% too much -> it will multiply spawn rate by 0.8 to reduce chance
+            // so if rocks have 20% rate to spawn, and you have 150 rocks when you should have 100, it adjusts it to 20% * 0.8 = 16% chance to spawn rocks
+            // to debug you can print for each islandSpawner the contents of
+            // private let spawnsPerType = new HashMap<int, int>()
+            // private let referenceItemCount = new HashMap<int,real>()
+            // spawnPerType contains how many items with ID have been spawned to the island
+            // referenceitemcount contains how many the system thinks "should" have been spawned
+            // and to see the current spawn rates you need to look at pool class
+            // in wurst/lib/Pool.wurst
+            // You gotta print the itemPool item weight / itemPool totalweight
+            // The pool is basically a weighted random selection pool class
+            // so if I put in A with weight 1 and B with weight 1 and C with weight 2
+            // I would have 25% chance to get A, 25% chance to get B and 50% chance to get C
+            // maybe you could add a function to Pool that returns the % chance of getting something
+
+            // Get adjusted spawn weights based on desired item counts from previous spawning round
+            let spawnInfo = this.weightMap.get(id)
+            let itemWeight = spawnInfo.getTimeAdjustedSpawnWeight()
+            var adjustmentRatio = 1.
+
+            if referenceItemCount.has(id) and spawnsPerType.has(id)
+                let desiredAmount = referenceItemCount.get(id)
+                let currentAmount = spawnsPerType.get(id)
+                if desiredAmount != 0 and currentAmount != 0
+                    let itemRatio = currentAmount / desiredAmount
+                    let difference = itemRatio - 1
+                    if difference > 0
+                        adjustmentRatio = linear(1, 1.2, min(1, (difference.abs() / 0.5)))
+                    else
+                        adjustmentRatio = linear(1, 0.8, min(1, (difference.abs() / 0.5)))
+
+            this.add((itemWeight * adjustmentRatio).round(), id)
+
+            //Update desired item counts for next spawning round
+            //Basically keeping count of the sum that the total items of that type should be at on average at the end of this spawn cycle
+            let weightRatio = itemWeight / totalWeight
+            let itemTotalThisRound = (itemsSpawnCount * gameConfig.getItemBase()).ceil()
+            if referenceItemCount.has(id)
+                referenceItemCount.put(id, referenceItemCount.get(id) + (itemTotalThisRound * weightRatio))
+            else
+                referenceItemCount.put(id, (itemTotalThisRound * weightRatio))

--- a/wurst/systems/spawns/ResourceSpawnsUtils.wurst
+++ b/wurst/systems/spawns/ResourceSpawnsUtils.wurst
@@ -62,10 +62,6 @@ public class FishSpawnComposer implements Composer
         this.allowedRegion = allowedRegion
     
     override function execute()
-        // Exit if the spawn limit has been reached.
-        if udg_FISH_CURRENT >= gameConfig.getFishMax()
-            return
-        
         let spawnPoint = this.allowedRegion.randomPoint()
         let targetID = this.units.random()
     

--- a/wurst/utils/Composer.wurst
+++ b/wurst/utils/Composer.wurst
@@ -1,0 +1,54 @@
+package Composer
+
+import Lodash
+import LinkedList
+import ClosureTimers
+
+public interface Composer
+    function execute()
+
+public class ConditionalComposer implements Composer
+    protected Composer Composer
+    protected EmptyFunction<bool> condition
+
+    construct(EmptyFunction<bool> condition, Composer Composer)
+        this.Composer = Composer
+        this.condition = condition
+
+    override function execute()
+        if this.condition.call()
+            this.Composer.execute()
+
+public class StaggeredComposer implements Composer
+    protected Composer Composer
+    protected int amount
+
+    construct(int amount, Composer Composer)
+        this.Composer = Composer
+        this.amount = amount
+
+    override function execute()
+        doPeriodicallyCounted(ANIMATION_PERIOD * 2, this.amount) fishHawkLoop ->
+            this.Composer.execute()
+
+public class RepeatComposer implements Composer
+    protected Composer Composer
+    protected int amount
+
+    construct(int amount, Composer Composer)
+        this.amount = amount
+        this.Composer = Composer
+
+    override function execute()
+        for i = 1 to this.amount
+            Composer.execute()
+
+public class MultipleComposer implements Composer
+    protected LinkedList<Composer> Composers
+
+    construct(LinkedList<Composer> Composers)
+        this.Composers = Composers
+
+    override function execute()
+        for Composer in Composers
+            Composer.execute()


### PR DESCRIPTION
I refactored the spawning system to make it more readable and removed weird semantics to know when animals/fishes died.

For the spawn system, I kept the overall same logic, and haven't touched the semantics of the weighted item pool and weighted animal pool except for making it in a separate class.

currentItems starts at -2 because the gatherer in the tutorial makes a fire