### PR TITLE
Corrected ability ID for Blink in Medallion of the Thief.

### DIFF
--- a/wurst/objects/items/Raw.wurst
+++ b/wurst/objects/items/Raw.wurst
@@ -86,7 +86,7 @@ import LocalObjectIDs
 
 @compiletime function create_w3t_I023()
 	let _def = createObjectDefinition("w3t", 'I023', 'hlst')
-	..setString("iabi", "A01W,A031")
+	..setString("iabi", commaList(ABILITY_TELEPORT, 'A031'))
 	..setString("iico", "ReplaceableTextures\\CommandButtons\\BTNMedalionOfCourage.blp")
 	..setString("icla", "Purchasable")
 	..setString("icid", "AEbl")


### PR DESCRIPTION
$changelog: Fixed bug where Medallion of the Thief was not usable.

The old ability was accidentally deleted when cleaning up legacy object definitions [here](https://github.com/island-troll-tribes/island-troll-tribes/commit/9642ce3bb2c7b86ae939ee4724c4f001a45866b7#diff-44e570ae16a7f44a386fa54403d8ce856804999f8fb20f0a54d6c5dad228c237L648-L662). Rather than reverting that deletion, the ability was switched to match the one used by Thief, `ABILITY_TELEPORT`. All of the relevant parameters are the same, except that the casting time is now 0 instead of 0.2, which also matches the original Blink in the base game.