### PR TITLE
Changed duration inputs for modes to use seconds instead of minutes.

### DIFF
--- a/wurst/systems/modes/ForcedDuel.wurst
+++ b/wurst/systems/modes/ForcedDuel.wurst
@@ -46,5 +46,5 @@ function moveTrollsToArena()
 init
     registerGameStartEvent() ->
         if gameConfig.isForcedDuelEnabled()
-            let timeout = gameConfig.getForcedDuelAfter() * 60
-            DUEL_TIMER = getTimer()..doAfter(timeout, () -> moveTrollsToArena())
+            let timeout = gameConfig.getForcedDuelAfter()
+            DUEL_TIMER = getTimer()..doAfter(timeout.toReal(), () -> moveTrollsToArena())

--- a/wurst/systems/modes/GameConfig.wurst
+++ b/wurst/systems/modes/GameConfig.wurst
@@ -10,8 +10,8 @@ class GameConfig
     var allTrollUnitId = 0
     var startingLevel = 0
     var forcedDuelEnabled = false
-    var forcedDuelAfter = 0.0
-    var gracePeriodDuration = 8.0
+    var forcedDuelAfter = 0
+    var gracePeriodDuration = 480
     var respawnSystemEnabled = false
     var randomizeSpawns = 0
     var startWithFire = false
@@ -24,7 +24,7 @@ class GameConfig
     var tradeEnabled = true
     var forestFireEnabled = false
     var forestFireDistance = 0.0
-    var forestFireAfter = 0.0
+    var forestFireAfter = 0
     var testMode = false
     var useOldMage = false
     var inventoryLimits = true
@@ -70,7 +70,7 @@ class GameConfig
 
     function getDisabledBoats() returns boolean
         return disabledBoats
-    
+
     function setDisabledBoats(boolean value)
         disabledBoats = value
 
@@ -82,19 +82,19 @@ class GameConfig
 
     function getFoodForKillProportion() returns real
         return foodForKillProportion
-    
+
     function setFoodForKillProportion(real amount)
         foodForKillProportion = amount
 
     function getLavish() returns boolean
         return lavish
-    
+
     function setLavish(boolean value)
         lavish = value
-    
+
     function getFamine() returns boolean
         return famine
-        
+
     function setFamine(boolean value)
         famine = value
 
@@ -106,25 +106,25 @@ class GameConfig
 
     function getItemBase() returns real
         return itemBase
-    
+
     function setItemBase(real amount)
         itemBase = amount
-    
+
     function getFastMode() returns boolean
         return fastMode
-    
+
     function setFastMode(boolean value)
         fastMode = value
 
     function getMaxFishes() returns int
         return maxFishes
-    
+
     function setMaxFishes(int amount)
         maxFishes = amount
 
     function getMaxItems() returns int
         return maxItems
-    
+
     function setMaxItems(int amount)
         maxItems = amount
 
@@ -160,17 +160,17 @@ class GameConfig
     function getNumPlayersPerTribe() returns integer
         return playersPerTribe
 
-    function setForcedDuel(real numMinutes) returns boolean
-        if numMinutes < gracePeriodDuration
+    function setForcedDuel(int numSeconds) returns boolean
+        if numSeconds < gracePeriodDuration
             return false
         forcedDuelEnabled = true
-        forcedDuelAfter = numMinutes
+        forcedDuelAfter = numSeconds
         return true
 
     function isForcedDuelEnabled() returns boolean
         return forcedDuelEnabled
 
-    function getForcedDuelAfter() returns real
+    function getForcedDuelAfter() returns int
         return forcedDuelAfter
 
     function isRespawnSystemEnabled() returns boolean
@@ -179,13 +179,13 @@ class GameConfig
     function setRespawnSystemEnabled(boolean value)
         respawnSystemEnabled = value
 
-    function setGracePeriodDuration(real numMinutes) returns boolean
-        if forcedDuelEnabled and numMinutes > forcedDuelAfter
+    function setGracePeriodDuration(int numSeconds) returns boolean
+        if forcedDuelEnabled and numSeconds > forcedDuelAfter
             return false
-        gracePeriodDuration = numMinutes
+        gracePeriodDuration = numSeconds
         return true
 
-    function getGracePeriodDurationMinutes() returns real
+    function getGracePeriodDuration() returns int
         return gracePeriodDuration
 
     function isGracePeriodEnabled() returns boolean
@@ -251,15 +251,15 @@ class GameConfig
     function getTradeEnabled() returns boolean
         return tradeEnabled
 
-    function setForestFire(real numMinutes, real distance)
+    function setForestFire(int numSeconds, real distance)
         forestFireEnabled = true
-        forestFireAfter = numMinutes
+        forestFireAfter = numSeconds
         forestFireDistance = distance
 
     function isForestFireEnabled() returns boolean
         return forestFireEnabled
 
-    function getForestFireAfter() returns real
+    function getForestFireAfter() returns int
         return forestFireAfter
 
     function getForestFireDistance() returns real
@@ -273,13 +273,13 @@ class GameConfig
 
     function getStatLossAmount() returns int
         return statDegradeAmount
-    
+
     function setStatLossAmount(int amount)
         statDegradeAmount = amount
 
     function getStatLossInterval() returns real
         return statLowerInterval
-    
+
     function setStatLossInterval(real amount)
         statLowerInterval = amount
 

--- a/wurst/systems/modes/GameModeInit.wurst
+++ b/wurst/systems/modes/GameModeInit.wurst
@@ -169,14 +169,14 @@ init
         mode.message("Old random enabled, you can now random any class")
         gameConfig.setOldRandomEnabled(true)
 
-    new GameMode("grace-period-duration", "gp", "General", "Change the duration of the grace period, eg: \"-gp 8\"") (mode, args) ->
-        var amount = 8.0
+    new GameMode("grace-period-duration", "gp", "General", "Change the duration of the grace period, eg: \"-gp 480\"") (mode, args) ->
+        var amount = 480
         if (args.size() > 1)
-            amount = args.get(1).toReal()
+            amount = args.get(1).toInt()
         if (not gameConfig.setGracePeriodDuration(amount))
             mode.error("Grace period must end before forced duel")
         else
-            mode.message("Grace period duration ".color(ENERGY_COLOR) + amount.toInt().toString() + " min")
+            mode.message("Grace period duration ".color(ENERGY_COLOR) + amount.toString() + " seconds")
 
     new GameMode("quick-pick", "qp", "General", "Reduce class selection time, defaults to 5, eg: \"-qp 15\"") (mode, args) ->
         var timeAllowed = 5
@@ -194,26 +194,26 @@ init
         mode.message("Respawn system".color(ENERGY_COLOR) + " enabled")
 
     new GameMode("forced-duel", "fd", "Pro", "Set a forced duel after a time limit, defaults to 1 h, eg: \"-fd 60\"") (mode, args) ->
-        var amount = 60.0
+        var amount = 3600
         if (args.size() > 1)
-            amount = args.get(1).toReal()
+            amount = args.get(1).toInt()
         if (not gameConfig.setForcedDuel(amount))
             mode.error("Force duel must be after end of the grace period")
         else
-            mode.message("Forced duel".color(ENERGY_COLOR) + " after " + amount.toInt().toString() + " min")
+            mode.message("Forced duel".color(ENERGY_COLOR) + " after " + amount.toString() + " seconds.")
 
     new GameMode("shrinking-map", "sm", "Fun", "Forest fire shrinks map after a default of 60 minutes to a default of 4000 units from center, eg: \"-sm 60 4000\"") (mode, args) ->
-        var amount = 60.0
+        var amount = 3600
         var distance = 4000.0
         if (args.size() > 1)
-            amount = args.get(1).toReal()
+            amount = args.get(1).toInt()
         if (args.size() > 2)
             distance = args.get(2).toReal()
         if (amount < 0)
             mode.error("Shrinking map timeout must be greater than 0!")
         else
             gameConfig.setForestFire(amount, distance)
-            mode.message("Forest fire".color(RED_COLOR) + " after " + amount.toInt().toString() + " min")
+            mode.message("Forest fire".color(RED_COLOR) + " after " + amount.toString() + " seconds.")
 
     new GameMode("test-mode", "tm", "Testing", "No one can lose, enables test commands") (mode, args) ->
         mode.message("Test mode enabled".color(SPECIAL_COLOR))

--- a/wurst/systems/modes/Respawn.wurst
+++ b/wurst/systems/modes/Respawn.wurst
@@ -54,8 +54,8 @@ init
 
     registerGameStartEvent() ->
         if gameConfig.isGracePeriodEnabled()
-            let numSeconds = gameConfig.getGracePeriodDurationMinutes() * 60
-            GRACE_PERIOD_TIMER.start(numSeconds) ->
+            let numSeconds = gameConfig.getGracePeriodDuration()
+            GRACE_PERIOD_TIMER.start(numSeconds.toReal()) ->
                 let msg = "{0}Grace period is over. Now you will not be automatically revived when you die! You can still be revived if your team builds a |c00ff0000Spirit Ward|r{1}!|r".format(GENERAL_COLOR.toColorString(), GENERAL_COLOR.toColorString())
                 printTimed(msg, 15)
                 MAMMOTH_GATE.kill()

--- a/wurst/systems/modes/ShrinkingMap.wurst
+++ b/wurst/systems/modes/ShrinkingMap.wurst
@@ -63,5 +63,5 @@ function burnThings()
 init
     registerGameStartEvent() ->
         if gameConfig.isForestFireEnabled()
-            let timeout = gameConfig.getForestFireAfter() * 60
-            FOREST_FIRE_TIMER = getTimer()..doAfter(timeout, () -> burnThings())
+            let timeout = gameConfig.getForestFireAfter()
+            FOREST_FIRE_TIMER = getTimer()..doAfter(timeout.toReal(), () -> burnThings())


### PR DESCRIPTION
$changelog: Changed modes that set a timer, such as grace period and forced duel, to use seconds instead of minutes.

This gives more flexibility without having to resort to decimals, but still isn't ideal. Longterm, we probably want an `Interval` type of some sort that automatically interfaces between `real` and `int` and supports combing seconds and minutes, e.g. `"06:30".toInterval() == Interval(6.5) == Interval(390)`.