### PR TITLE
Used ability definition for sound effects when moving corpses.

### DIFF
--- a/wurst/assets/LocalAssets.wurst
+++ b/wurst/assets/LocalAssets.wurst
@@ -306,3 +306,7 @@ public class UnitClasses
     static constant walkable   = "standon"
     static constant ward       = "ward"
     static constant worker     = "peon"
+
+// This directory is similar to Sound but is used for ability sound effects.
+public class SoundEffects
+    static constant loadUnload = "LoadUnload"

--- a/wurst/objects/abilities/MoveCorpses.wurst
+++ b/wurst/objects/abilities/MoveCorpses.wurst
@@ -13,7 +13,6 @@ import HashList
 import ObjectIds
 import ObjectIdGenerator
 import Orders
-import SoundUtils
 
 // Local imports:
 import ColorUtils
@@ -23,9 +22,6 @@ import PlayerExtensions
 import SimError
 import StringExtensions
 import Transformation
-
-// Cargo Load sound effect used for corpse grab/drop
-let CORPSE_LOAD_SOUND = new SoundDefinition(Sounds.loading, false, true)
 
 // The time for which new abilities are disabled to prevent accidental rollback.
 // TODO: Use a per-player setting for this.
@@ -128,7 +124,9 @@ let switches = new HashMap<int, int>()
             ..setButtonPositionNormalY(POSITION_Y)
             // The hotkey is not positional.
             ..setHotkeyNormal("C")
-            // The corpse is removed without an effect.
+            // Set the sound effect separately from the art effect.
+            ..setEffectSound(SoundEffects.loadUnload)
+            // The corpse is grabbed without an art effect.
             ..setArtEffect("")
             // The ability only ever summons a single dummy unit.
             ..setLevels(1)
@@ -157,10 +155,13 @@ let switches = new HashMap<int, int>()
             ..setButtonPositionNormalY(POSITION_Y)
             // The hotkey is not positional.
             ..setHotkeyNormal("C")
-            // Remove the actual effect.
+            // Set the sound effect separately from the art effect.
+            ..setEffectSound(SoundEffects.loadUnload)
+            // The corpse is dropped without an art effect.
             ..setArtCaster("")
             ..setArtTarget("")
             ..setArtSpecial("")
+            // Remove the actual effect.
             ..presetBuffs(lvl -> "")
             ..presetHitPointsGained(lvl -> 0)
             ..presetManaPointsGained(lvl -> 0)
@@ -231,7 +232,6 @@ function switchAbilities(unit target) returns int
 function onDrop(unit caster)
     // Create the corpse that is dropped.
     createCorpse(caster.getPos())
-    CORPSE_LOAD_SOUND.playOnPoint(caster.getPos3Real())
 
     // Decrement the count.
     updateCount(caster, -1)
@@ -243,7 +243,6 @@ function onGrab(unit caster, unit target)
 
     // Remove the target, as its purpose is only to trigger this event.
     target.remove()
-    CORPSE_LOAD_SOUND.playOnPoint(caster.getPos3Real())
 
     // Increment the count.
     updateCount(caster, 1)


### PR DESCRIPTION
I'll update this description if this change turns out to address desyncs. Using the `getPos3Real` may cause desyncs due to using `GetLocationZ`, but this is not yet confirmed. Keeping this change regardless because it's makes sense to use object fields over triggers when appropriate.