### PR TITLE
Corrected checks for local player when displaying hints.

### DIFF
--- a/wurst/systems/commands/Hints.wurst
+++ b/wurst/systems/commands/Hints.wurst
@@ -27,7 +27,7 @@ let HINTS_MESSAGE = compiletime(
 )
 let HINT_SOUND = compiletime(new SoundDefinition(Sounds.hint, false))
 
-// The global hint used for reference when enumerating the force.
+// The global variable used for reference when enumerating the force.
 // TODO: Remove the need for this by using LinkedList<player> instead of force.
 Hint enumHint = null
 

--- a/wurst/systems/commands/Hints.wurst
+++ b/wurst/systems/commands/Hints.wurst
@@ -27,7 +27,7 @@ let HINTS_MESSAGE = compiletime(
 )
 let HINT_SOUND = compiletime(new SoundDefinition(Sounds.hint, false))
 
-// The global variable used for reference when enumerating the force.
+// The global variable used for reference when enumerating over the force.
 // TODO: Remove the need for this by using LinkedList<player> instead of force.
 Hint enumHint = null
 

--- a/wurst/systems/commands/Hints.wurst
+++ b/wurst/systems/commands/Hints.wurst
@@ -17,7 +17,7 @@ import StringExtensions
 import UnitExtensions
 import IdListConstant
 
-let TIME_BETWEEN_HINTS = 50.0
+let TIME_BETWEEN_HINTS = 15.0
 let HINTS_MESSAGE = compiletime(
     asList(
         "Your hints are now ".color(GENERAL_COLOR),
@@ -26,6 +26,10 @@ let HINTS_MESSAGE = compiletime(
     ).join()
 )
 let HINT_SOUND = compiletime(new SoundDefinition(Sounds.hint, false))
+
+// The global hint used for reference when enumerating the force.
+// TODO: Remove the need for this by using LinkedList<player> instead of force.
+Hint enumHint = null
 
 
 class Hint
@@ -60,11 +64,13 @@ class Hint
             Hint.addPlayer(p)
 
     function display()
-        if playersF.containsPlayer(localPlayer)
-            printTimed(this.toString(), 10)
-            if ping != vec2(0, 0)
-                pingMinimap(ping)
-            HINT_SOUND.playForPlayer(localPlayer)
+        enumHint = this
+        playersF.forEach() ->
+            let target = GetEnumPlayer()
+            target.print(enumHint.toString(), 10)
+            if enumHint.ping != vec2(0, 0)
+                pingMinimapForPlayer(target, enumHint.ping)
+            HINT_SOUND.playForPlayer(target)
 
     static function initialize()
         for i = 0 to bj_MAX_PLAYERS - 1

--- a/wurst/systems/commands/Hints.wurst
+++ b/wurst/systems/commands/Hints.wurst
@@ -17,7 +17,7 @@ import StringExtensions
 import UnitExtensions
 import IdListConstant
 
-let TIME_BETWEEN_HINTS = 15.0
+let TIME_BETWEEN_HINTS = 50.0
 let HINTS_MESSAGE = compiletime(
     asList(
         "Your hints are now ".color(GENERAL_COLOR),


### PR DESCRIPTION
$changelog: Fixed bug where players would desync depending on their setting for hints.

The desync was caused by encapsulating the whole block in a comparison against `localPlayer`, specifically because `HINT_SOUND.playForPlayer` changes instance fields, which are global variables.

Instead a loop is used so the same adjustment is made for everyone and then the lower level actions are responsible for checks against `localPlayer`, which ensures that only basic native calls are inside of `localPlayer` checks.