### PR TITLE
Added back missing BattleTags to skins registry.

### DIFF
--- a/wurst/systems/commands/Skins.wurst
+++ b/wurst/systems/commands/Skins.wurst
@@ -140,25 +140,33 @@ init
         if getTrollClassType(target) != getTrollClassType(unitID)
             onEnterHandler(target)
 
-    CustomSkin.lookup(UNIT_BOOSTER).register(
-        "Mambo#11709",
-        "MasterTroll#11111"
-    )
+    CustomSkin.lookup(UNIT_BOOSTER)
+        ..register("Davee3#2699")
+        ..register("Mambo#11709")
+        ..register("MasterTroll#11111")
+        ..register("Quantum#1149")
+        ..register("Quazz#1753")
+        ..register("Srup#1240")
+        ..register("Viking#1822")
 
-    CustomSkin.lookup(UNIT_HUNTER).register(
-        "Mambo#11709"
-    )
+    CustomSkin.lookup(UNIT_HUNTER)
+        ..register("Davee3#2699")
+        ..register("Mambo#11709")
+        ..register("Quantum#1149")
+        ..register("Quazz#1753")
+        ..register("Srup#1240")
 
-    CustomSkin.lookup(UNIT_MASTER_HEALER).register(
-    )
+    CustomSkin.lookup(UNIT_MASTER_HEALER)
+        ..register("Quantum#1149")
 
-    CustomSkin.lookup(UNIT_MAGE).register(
-        "Mambo#11709"
-    )
+    CustomSkin.lookup(UNIT_MAGE)
+        ..register("Davee3#2699")
+        ..register("Mambo#11709")
+        ..register("Quantum#1149")
 
-    CustomSkin.lookup(UNIT_ELEMENTALIST_NEW).register(
-        "Mambo#11709"
-    )
+    CustomSkin.lookup(UNIT_ELEMENTALIST_NEW)
+        ..register("Mambo#11709")
+        ..register("Quantum#1149")
 
-    CustomSkin.lookup(UNIT_BEAST_MASTER).register(
-    )
+    CustomSkin.lookup(UNIT_BEAST_MASTER)
+        ..register("Quantum#1149")


### PR DESCRIPTION
Added back some missing entries now that I know the new BattleTag matching these usernames.

Changed the formatting to not use `vararg` inputs because require extra lines in the differential due to the lack of support for trailing commas. With one input per call to `register`, adding a new player to a skin just requires adding a line, without adding a comma to a different line.