### PR TITLE
Reduced snake poison effects.

### DIFF
--- a/wurst/objects/abilities/BaseMapAbilities.wurst
+++ b/wurst/objects/abilities/BaseMapAbilities.wurst
@@ -109,8 +109,8 @@ import ObjectIds
         ..setDamagePerSecond(1, 0.0)
         ..setMovementSpeedFactor(1, 0.35)
         ..setAttackSpeedFactor(1, 0.07)
-        ..setDurationNormal(1, 300.0)
-        ..setDurationHero(1, 120.0)
+        ..setDurationNormal(1, 30.0)
+        ..setDurationHero(1, 30.0)
 
     // The one ability
     new AbilityDefinitionHardenedSkin(ABILITY_HARDENED_SKIN)

--- a/wurst/objects/abilities/BaseMapAbilities.wurst
+++ b/wurst/objects/abilities/BaseMapAbilities.wurst
@@ -107,10 +107,10 @@ import ObjectIds
 
     new AbilityDefinitionSlowPoison(ABILITY_SNAKE_POISON)
         ..setDamagePerSecond(1, 0.0)
-        ..setMovementSpeedFactor(1, 0.35)
+        ..setMovementSpeedFactor(1, 0.20)
         ..setAttackSpeedFactor(1, 0.07)
-        ..setDurationNormal(1, 30.0)
-        ..setDurationHero(1, 30.0)
+        ..setDurationNormal(1, 150.0)
+        ..setDurationHero(1, 120.0)
 
     // The one ability
     new AbilityDefinitionHardenedSkin(ABILITY_HARDENED_SKIN)


### PR DESCRIPTION
$changelog: Reduced movement speed reduction for Snake poison from 35% to 20%.
$changelog: Reduced duration for non-heroes for Snake poison from 300 to 150 seconds.

Snake poison is too annoying, 2min is way too long, I don't understand the purpose of this duration, I reduced it to 30 seconds so if you get attacked by a snake when you are escaping/fighting with other troll, it still feels like it has an impact.