### PR TITLE
Reverted health and armor type for some buildings.

### DIFF
--- a/wurst/objects/units/TrollBuildings.wurst
+++ b/wurst/objects/units/TrollBuildings.wurst
@@ -63,6 +63,9 @@ function createBuilding(int newId, int oldId) returns BuildingDefinition
         ..setTooltipBasic("You can mix herbs inside this pot.")
         ..setTooltipExtended("This pot is so big it is able to hold large amounts of boiling water. Inside, herbs can be mixed into potions.")
         ..setName("Mixing Pot")
+        ..setHitPointsMaximumBase(260)
+        ..setArmorType(ArmorType.Large)
+        ..setDeathTimeseconds(1)
 
 @compiletime function createTannery() returns BuildingDefinition
     return createBuilding(UNIT_TANNERY)
@@ -73,6 +76,7 @@ function createBuilding(int newId, int oldId) returns BuildingDefinition
         ..setTooltipBasic("You can turn hides into armor here.")
         ..setTooltipExtended("This pot is so big it is able to hold large amounts of boiling water. Inside, herbs can be mixed into potions.")
         ..setName("Tannery")
+        ..setHitPointsMaximumBase(275)
 
 @compiletime function createArmory() returns BuildingDefinition
     return createBuilding(UNIT_ARMORY)
@@ -103,6 +107,7 @@ function createBuilding(int newId, int oldId) returns BuildingDefinition
         ..setTooltipBasic("You can create a variety of magical items here.")
         ..setTooltipExtended("You can create a variety of magical items here.")
         ..setName("Witch Doctor's Hut")
+        ..setHitPointsMaximumBase(325)
 
 @compiletime function createWorkshop() returns BuildingDefinition
     return createBuilding(UNIT_WORKSHOP)
@@ -113,6 +118,7 @@ function createBuilding(int newId, int oldId) returns BuildingDefinition
         ..setTooltipBasic("You can create a variety of magical items here.")
         ..setTooltipExtended("You can create a variety of magical items here.")
         ..setName("Workshop")
+        ..setArmorType(ArmorType.Large)
 
 init
     // Register the indicators to create neutral units on the island.


### PR DESCRIPTION
$changelog: Reverted health for Mixing Pot, Workshop, and Witch Doctor's Hut from 250 to 260, 275, and 325, respectively .
$changelog: Reverted armor type for Mixing Pot and Workshop from Fortified to Heavy.

I've noticed those changes compared to 3.2 version, I believe this is an oversight from rewriting the troll buildings definition. Building HP should scale with their price.