### PR TITLE
Fixed scoreboard timer for observers.

### DIFF
--- a/wurst/systems/boards/ScoreBoard.wurst
+++ b/wurst/systems/boards/ScoreBoard.wurst
@@ -238,6 +238,9 @@ init
                     for member in tribe.getMembers()
                         scoreBoardEntries.get("Level")
                         .updateEntryIcon(member.getName(), member.getTrollIcon())
+                doPeriodically(1) (CallbackPeriodic cb) ->
+                    let title = getGameTimersBoardTitle()
+                    scoreBoard.board.setTitle(title)
 
     // Block this command from being used prior to the tribe board creation.
     registerGameStartEvent() ->

--- a/wurst/systems/boards/ScoreBoard.wurst
+++ b/wurst/systems/boards/ScoreBoard.wurst
@@ -239,8 +239,7 @@ init
                         scoreBoardEntries.get("Level")
                         .updateEntryIcon(member.getName(), member.getTrollIcon())
                 doPeriodically(1) (CallbackPeriodic cb) ->
-                    let title = getGameTimersBoardTitle()
-                    scoreBoard.board.setTitle(title)
+                    scoreBoard.board.setTitle(getGameTimersBoardTitle())
 
     // Block this command from being used prior to the tribe board creation.
     registerGameStartEvent() ->


### PR DESCRIPTION
$changelog: Fixed scoreboard timer for observers.

When I rewrote scoreboard, I made it so it only update on event such as kill/item sold, but I forgot to periodically update the board timer.