### PR TITLE
Increased mana drain per hit on Mage Masher.

### DIFF
--- a/wurst/objects/items/MageMasher.wurst
+++ b/wurst/objects/items/MageMasher.wurst
@@ -11,7 +11,7 @@ import UnitEntity
 import DummyCaster
 
 let MANABURN_ID = compiletime(ABIL_ID_GEN.next())
-let DRAIN_AMOUNT = 6.
+let DRAIN_AMOUNT = 10.
 
 @compiletime function createDummyManaburn()
     new AbilityDefinitionManaBurndemon(MANABURN_ID)


### PR DESCRIPTION
$changelog: Increased mana drain per hit on Mage Masher from 6 to 10.

With mage and priest having a mana pool of 350 mage masher feels like a butter knife. This will give it slightly more power. Longer term we may want to consider % drain.