### PR TITLE
Increased stock replenish interval for crafted materials.

### DIFF
--- a/wurst/objects/items/Items.wurst
+++ b/wurst/objects/items/Items.wurst
@@ -30,6 +30,7 @@ function createBasicItem(int newId, int oldId) returns ItemDefinition
         ..setClassification("Permanent")
         ..setMaxStack(0)
         ..setAbilities("")
+        ..setStockReplenishInterval(120)
 
 function createUsableItem(int newId, int oldId) returns ItemDefinition
     return createBasicItem(newId, oldId)


### PR DESCRIPTION
$changelog: Increased the stock replenish interval on merchants from 60 to 120 seconds for crafted materials, including ingots, spirits, and poisons.

I forgot to set the stock replenish interval for the crafted materials definition when I rewrote them. I checked all current items replenish interval and compared them with the version 3.2, here's a list of current items stock interval :

-Most buildings kits had & have 30 seconds, magic seed being the exception with 180
-Scrolls had 180, they currently have 120
-Basic materials (stick, tinder, clay, flint) have & had 120
-Crafted materials had 120, they have 60 after 3.6b if my memory is correct.
-Shields & Axes had 180, they have 120 after 3.4a I believe, I set it to 120 when I rewrote them.
-Iron coat & boots had 60, they have 120, iron gloves had & have 120
-Spear had & have 120
-Blow gun had & have 30

I didn't set the stock replenish interval for individual definition of crafted materials item, I added it to the "parent" definition as most items have 120 seconds interval.