### PR TITLE
Removed slowing effect from Depression Aura.

### DIFF
--- a/wurst/objects/abilities/mage/hypnotist/DepressionAura.wurst
+++ b/wurst/objects/abilities/mage/hypnotist/DepressionAura.wurst
@@ -6,13 +6,13 @@ import ToolTipsUtils
 import ChannelAbilityPreset
 import Assets
 
-let AS_REDUCED = 0.10
-let MS_REDUCED = 0.10
+let AS_REDUCED = 0.00
+let MS_REDUCED = 0.00
 
 let ICON_PATH = "ReplaceableTextures\\CommandButtons\\PASBTNShadowPact.blp"
 let TOOLTIP_NORM = "Depression Aura"
 let TOOLTIP_EXTENDED = ("The Hypnotist spend many time studying dark magic, he can passively generate a field of depression around him. Units that enter "+
-                       "it got their attack and movement speed reduced by {0}, they also loose energy quickly. Stacks with depression. ")
+                       "it loose energy quickly. Stacks with depression. ")
                        .format(AS_REDUCED.toToolTipOrange())
 
 let TARGET_ALLOWED = "enemies,ground,hero,organic,vulnerable"


### PR DESCRIPTION
$changelog: Removed slowing effect from Depression Aura.

I've seen people voting (4 to 0) this change in the suggestion channel from the ITT discord, pretty sure nobody would disagree with this, everybody have been saying for month that elementalist & hypnotist are busted.