### PR TITLE
Corrected attack range motion buffer for pet Elk.

### DIFF
--- a/wurst/objects/units/Animals/ElkDefinition.wurst
+++ b/wurst/objects/units/Animals/ElkDefinition.wurst
@@ -68,6 +68,7 @@ class ElkAttackerDefinition extends ElkDefinition
         this.setAttack1WeaponType(WeaponType.Normal)
         this.setAttack1AttackType(AttackType.Pierce)
         this.setAttacksEnabled(1)
+        this.setAttack1RangeMotionBuffer(250)
         this.setSpeedBase(350)
         this.setLevel(0)
         this.setPointValue(200)


### PR DESCRIPTION
$changelog: Fixed bug where a pet Elk would miss when attacking a fleeing target.

The attack range motion buffer for elk was set to 0 as the original unit is a critter and do not have an attack, I can't tell why it wasn't an issue with previous elk pet definition, maybe because it used to attack with missile and not melee.