### PR TITLE
Fixed bug where scoreboard displayed prematurely in 3+ team games.

### DIFF
--- a/wurst/systems/boards/ScoreBoard.wurst
+++ b/wurst/systems/boards/ScoreBoard.wurst
@@ -29,7 +29,7 @@ let NAME_LABEL_WIDTH = 0.13
 let LEVEL_LABEL_WIDTH = 0.05
 
 let iconPlayerInGame = "UI\\widgets\\escmenu\\nightelf\\nightelf-checkbox-depressed.blp"
-let iconPlayerDefeated = "UI\\widgets\\escmenu\\orc\\orc-checkbox-depressed.blp"
+public let iconPlayerDefeated = "UI\\widgets\\escmenu\\orc\\orc-checkbox-depressed.blp"
 
 class Category
     string text

--- a/wurst/systems/core/Tribe.wurst
+++ b/wurst/systems/core/Tribe.wurst
@@ -17,6 +17,7 @@ import PlayerExtensions
 import StringExtensions
 import initlater TribeBoard
 import initlater Boards
+import initlater ScoreBoard
 
 let listeners = CreateTrigger()
 
@@ -125,7 +126,8 @@ public class Tribe
             TribeBoard.findForPlayer(member).board.display(member, false)
 
             // Enabling the score board, maximizing it so the player doesn't miss it
-            scoreBoard.board..display(true)..maximize(member)
+            // scoreBoard.board..display(true)..maximize(member)
+            scoreBoard.board..display(member, true)..maximize(member)
 
     function displayDefeated()
         // Displaying which tribe has been defeated to every player & observer
@@ -135,6 +137,9 @@ public class Tribe
     function wasDefeated()
         makePlayersObservers()
         defeated = true
+        scoreBoardEntries.get("PlayerName")
+            .updateEntry(this.name, this.name, iconPlayerDefeated)
+
         if tribe.containsPlayer(GetLocalPlayer())
             print("You have been defeated.".color(HIGHLIGHT_COLOR))
         // TODO: Remove this once tribes mode is merged into default game.

--- a/wurst/systems/core/Tribe.wurst
+++ b/wurst/systems/core/Tribe.wurst
@@ -126,7 +126,6 @@ public class Tribe
             TribeBoard.findForPlayer(member).board.display(member, false)
 
             // Enabling the score board, maximizing it so the player doesn't miss it
-            // scoreBoard.board..display(true)..maximize(member)
             scoreBoard.board..display(member, true)..maximize(member)
 
     function displayDefeated()


### PR DESCRIPTION
$changelog: Fixed bug where the scoreboard would be displayed prematurely in games with many tribes.

I forgot to specify player in the scoreboard display method upon a tribe defeat, therefore it displayed the scoreboard for every one when 1 tribe was defeated.
Also fixed the square icon next to the tribe name which now turns red when a tribe is defeated.