### PR TITLE
Reverted base Scout ability to Radar instead of Ward the Area.

### DIFF
--- a/wurst/objects/units/TrollUnitTextConstant.wurst
+++ b/wurst/objects/units/TrollUnitTextConstant.wurst
@@ -70,7 +70,7 @@ public constant  NORMAL_SPELLS_MAGE         = commaList(ABILITY_NEGATIVE_BLAST)
 public constant  NORMAL_SPELLS_PRIEST       = commaList(ABILITY_THE_GLOW)
 public constant  NORMAL_SPELLS_BEAST_MASTER = commaList(ABILITY_PET_SPELLS,ABILITY_SPIRIT_BEAST)
 public constant  NORMAL_SPELLS_THIEF        = commaList(ABILITY_TELEPORT)
-public constant  NORMAL_SPELLS_SCOUT        = commaList(ABILITY_WARD_AREA)
+public constant  NORMAL_SPELLS_SCOUT        = commaList(ABILITY_PING_ENEMY)
 public constant  NORMAL_SPELLS_GATHERER     = commaList(ABILITY_SALVE_RECIPE)
 
 // Sub Hero Spells


### PR DESCRIPTION
$changelog: Reverted base Scout ability to Radar instead of Ward the Area.

Current Ward the area is a starting ability for scout, it can place 1 ward lasting 480 seconds with a 70 seconds cooldown, this ability has replaced ping the enemy in #547 , the feedback from the player is mostly negative, issue being that this spell is quite useless as a lvl 1 spell compared to ping the enemy. 

It has a high cooldown for placing only 1 ward, in comparison, you can craft 6 ward with 2 clay & a mc from workshop which is clearly cheap, it makes this ability feels useless. 

At level 1, scout used to be able to accompany a hunter/bm to hunt more effectively using radar, this isn't possible with current ward ability which you can't use unless you... rush middle island to ward I guess? Well I find rare occasion where I can use it and the cooldown is way too high. I am certain giving radar back will buff scout and please current player base.