### PR TITLE
Fixed conflict for several order IDs.

### DIFF
--- a/wurst/lib/OrderStringFactory_config.wurst
+++ b/wurst/lib/OrderStringFactory_config.wurst
@@ -6,9 +6,9 @@ import HashSet
 let banned = new HashSet<string>()..add(
     "frostnova",       // Mage - Negative Blast
     "cripple",         // Mage - Null Damage
-    "waterelemental",  // Mage - Mage Fire
+    "waterelemental",  // Mage - Mage Fire - Sage - Light gate
     "soulburn",        // Mage - Metronome
-    "fanofknives",     // Mage - Flame Spray
+    "fanofknives",     // Mage - Flame Spray - Master Healer - Self preservation
     "acidbomb",        // Mage - Depress
     "unholyfrenzy",    // Hypnotist - Anger
     "sleep",           // Hypnotist - Sleep, Misc - Sleep Inside, Misc - Sleep Outside

--- a/wurst/objects/abilities/priest/masterhealer/SelfPreservation.wurst
+++ b/wurst/objects/abilities/priest/masterhealer/SelfPreservation.wurst
@@ -40,6 +40,7 @@ class SelfPreservation extends ChannelAbilityPreset
         this.setArtCaster(MODEL_PATH)
         this.setTargetAttachmentPoint("overhead")
         this.setCasterAttachmentPoint1("")
+        this.setBaseOrderID(1, "fanofknives")
 
 @compiletime function createAntiMagic()
     new SelfPreservation(ABILITY_SELF_PRESERVATION, "S", new Pair(1, 1))

--- a/wurst/objects/abilities/scout/ScoutRadars.wurst
+++ b/wurst/objects/abilities/scout/ScoutRadars.wurst
@@ -64,18 +64,16 @@ public class RadarSpell
     let id = '0'
     let btnPositionX = 0
     let btnPositionY = 0
-    let baseOrderId = "avatar"
     let cooldown = COOLDOWN
     let manaCost = 10
 
-    construct(string unitToPing, string toolTip, string iconPath, int id, int btnX, int btnY, string hotkey, string baseOrderId, int manaCost, string color)
+    construct(string unitToPing, string toolTip, string iconPath, int id, int btnX, int btnY, string hotkey, int manaCost, string color)
         this.name = GENERAL_COLOR.toColorString()+"[" + SPECIAL_COLOR.toColorString() + hotkey + GENERAL_COLOR.toColorString() + "] - " + this.name + color + unitToPing + "|r"
         this.toolTip += color+unitToPing + "|r surrounding your position." + toolTip
         this.iconPath += iconPath
         this.id = id
         this.btnPositionX = btnX
         this.btnPositionY = btnY
-        this.baseOrderId = baseOrderId
         this.hotkey = hotkey
         this.manaCost = manaCost
 
@@ -105,12 +103,12 @@ function getRadarSpells() returns LinkedList<RadarSpell>
         new RadarSpell("Elk|r"+GENERAL_COLOR.toColorString()+" and "+COLOR_RED.toColorString()+"Hostile Units" , TOOL_TIP_COOLDOWN, "BTNSpy.blp" , ABILITY_SPY_PING_ENEMY, 2, 1, "A", "stormbolt" , 0, COLOR_GREEN.toColorString()  ),
 
         //Advanced Radar Spells
-        new RadarSpell("Elk"              , TOOL_TIP_COOLDOWN, "BTNSpy.blp" , ABILITY_PING_ELK             , 0, 0, "Q", "locustswarm"   , MANACOST, COLOR_GREEN .toColorString() ),
-        new RadarSpell("Hawk"             , TOOL_TIP_COOLDOWN, "BTNSpy.blp" , ABILITY_PING_HAWK            , 0, 0, "W", "manashieldon"  , MANACOST, COLOR_TEAL  .toColorString() ),
-        new RadarSpell("Hostile Animals"  , TOOL_TIP_COOLDOWN, "BTNSpy.blp" , ABILITY_PING_HOSTILE_ANIMALS , 0, 0, "E", "manaflareoff"  , MANACOST, COLOR_RED   .toColorString() ),
-        new RadarSpell("Hostile Building" , TOOL_TIP_COOLDOWN, "BTNSpy.blp" , ABILITY_PING_BUILDING        , 0, 0, "R", "manaflareon"   , MANACOST, COLOR_ORANGE.toColorString() ),
-        new RadarSpell("Trolls"           , TOOL_TIP_COOLDOWN, "BTNSpy.blp" , ABILITY_PING_TROLL           , 0, 0, "A", "manashieldoff" , MANACOST, COLOR_RED   .toColorString() ),
-        new RadarSpell("Living Clay"      , TOOL_TIP_COOLDOWN, "BTNSpy.blp" , ABILITY_PING_LIVING_CLAY     , 0, 0, "S", "howlofterror"  , MANACOST, COLOR_PINK  .toColorString() )
+        new RadarSpell("Elk"              , TOOL_TIP_COOLDOWN, "BTNSpy.blp" , ABILITY_PING_ELK             , 0, 0, "Q", MANACOST, COLOR_GREEN .toColorString() ),
+        new RadarSpell("Hawk"             , TOOL_TIP_COOLDOWN, "BTNSpy.blp" , ABILITY_PING_HAWK            , 0, 0, "W", MANACOST, COLOR_TEAL  .toColorString() ),
+        new RadarSpell("Hostile Animals"  , TOOL_TIP_COOLDOWN, "BTNSpy.blp" , ABILITY_PING_HOSTILE_ANIMALS , 0, 0, "E", MANACOST, COLOR_RED   .toColorString() ),
+        new RadarSpell("Hostile Building" , TOOL_TIP_COOLDOWN, "BTNSpy.blp" , ABILITY_PING_BUILDING        , 0, 0, "R", MANACOST, COLOR_ORANGE.toColorString() ),
+        new RadarSpell("Trolls"           , TOOL_TIP_COOLDOWN, "BTNSpy.blp" , ABILITY_PING_TROLL           , 0, 0, "A", MANACOST, COLOR_RED   .toColorString() ),
+        new RadarSpell("Living Clay"      , TOOL_TIP_COOLDOWN, "BTNSpy.blp" , ABILITY_PING_LIVING_CLAY     , 0, 0, "S", MANACOST, COLOR_PINK  .toColorString() )
     )
 
 function onCast(LinkedList<int> unitId, real red, real green, real blue)

--- a/wurst/systems/crafting/QuickMakeSpell.wurst
+++ b/wurst/systems/crafting/QuickMakeSpell.wurst
@@ -348,7 +348,7 @@ function getQuickMakeSpells() returns LinkedList<QuickMakeSpell>
         new QuickMakeSpell("Mixing Pot Kit"        , TRANSMUTE_CRAFT_BUILDING_TOOLTIP+MIXING_POT_KIT_RECIPE        , "SacrificialPit"       , ABILITY_QM_MIXING_POT_KIT        , 2, 1, "D", QM_BUILD_TOOLIP, "chemicalrage"),
         new QuickMakeSpell("Witch Doctors Hut Kit" , TRANSMUTE_CRAFT_BUILDING_TOOLTIP+WITCH_DOCTORS_HUT_KIT_RECIPE , "VoodooLounge"         , ABILITY_QM_WITCH_DOCTORS_HUT_KIT , 3, 1, "F", QM_BUILD_TOOLIP, "creepanimatedead"),
         new QuickMakeSpell("Tannery Kit"           , TRANSMUTE_CRAFT_BUILDING_TOOLTIP+TANNERY_KIT_RECIPE           , "PigFarm"              , ABILITY_QM_TANNERY_KIT           , 0, 2, "Z", QM_BUILD_TOOLIP, "thunderclap"),
-        new QuickMakeSpell("Omnitower Kit"         , TRANSMUTE_CRAFT_BUILDING_TOOLTIP+OMNI_TOWER_KIT_RECIPE        , "OrcTower"             , ABILITY_QM_OMNI_TOWER_KIT        , 1, 2, "X", QM_BUILD_TOOLIP, "stomp"),
+        new QuickMakeSpell("Omnitower Kit"         , TRANSMUTE_CRAFT_BUILDING_TOOLTIP+OMNI_TOWER_KIT_RECIPE        , "OrcTower"             , ABILITY_QM_OMNI_TOWER_KIT        , 1, 2, "X", QM_BUILD_TOOLIP, "manashieldon"),
         new QuickMakeSpell("Armory Kit"            , TRANSMUTE_CRAFT_BUILDING_TOOLTIP+ARMORY_KIT_RECIPE            , "Armory"               , ABILITY_QM_ARMORY_KIT            , 2, 2, "A", QM_BUILD_TOOLIP, "locustswarm")
 
         // Second Buildings Page


### PR DESCRIPTION
$changelog: Fixed bug where Self-Preservation would not enter cooldown properly.
$changelog: Fixed bug where Restore Mana on Horn of the Mammoth would not activate properly.

Self preservation conflicted with quick make Witch doctors hut, horn of mana with quick make Omnitower Kit, we are bound to encounter more issue like this in the future as most channeled ability still rely on the orderId factory.