### PR TITLE
Nerfed Blowgun.

### DIFF
--- a/wurst/objects/items/Workshop/BlowgunDefinition.wurst
+++ b/wurst/objects/items/Workshop/BlowgunDefinition.wurst
@@ -28,19 +28,19 @@ let BONE_THISTLE_STUN_NORMAL = 2.0
 let THISTLE_DMG                = 15.
 let THISTLE_AS_FACTOR          = 0.3
 let THISTLE_MS_FACTOR          = 0.4
-let THISTLE_DECAYING_DMG       = 5.
+let THISTLE_DECAYING_DMG       = 1.
 let THISTLE_DECAY_POWER        = 0.5
 
 let THISTLE_HERO_DMG           = 10.
 let THISTLE_HERO_AS_FACTOR     = 0.15
 let THISTLE_HERO_MS_FACTOR     = 0.3
-let THISTLE_HERO_DECAYING_DMG  = 5.
+let THISTLE_HERO_DECAYING_DMG  = 1.
 let THISTLE_HERO_DECAY_POWER   = 0.5
 
 let DARK_THISTLE_DMG           = 20.
 let DARK_THISTLE_AS_FACTOR     = 0.2
 let DARK_THISTLE_MS_FACTOR     = 0.2
-let DARK_THISTLE_DECAYING_DMG  = 5.
+let DARK_THISTLE_DECAYING_DMG  = 1.
 let DARK_THISTLE_DECAY_POWER   = 0.5
 
 let THISTLE_DURATION_NORMAL = 16.
@@ -55,7 +55,7 @@ public let NUM_TICK = 6
 public let LEN_TICK = 1.
 public let DARK_THISTLE_MANA_BURN = 2.
 
-let COOLDOWN = 6.
+let COOLDOWN = 9.
 
 let ITEM_TOOLTIP = "Purchase |cffffcc00B|rlow Gun"
 


### PR DESCRIPTION
$changelog: Increased cooldown on Blowgun from 6 to 9 seconds for all types of ammunition.
$changelog: Decreased damage per tick for Thistle in Blowgun from 5 to 1.

I am having trouble reaching a solution regarding blowgun from first boat, in the end, you can just buy workshop & the material from first boat, doesn't seem like it would really solve the issue that blow gun is too strong, so I decided to nerf the numbers.

Thistles damage can deal 15 instant damage + 5 x 5 decaying damage over 16 seconds, In 3.2 it dealt 20 instant damage & 1 decaying damage, reducing decaying damage to 1 would also avoid issue with XP being given to another player due to dummycast changing owner, even though you can fix this by not using InstantDummyCaster, I don't really want to spend time on this, maybe later.

So my goal here is mostly to nerf the numbers and see what happens unless we can agree on something else.