### PR TITLE
Updated -obs command to end mode selection when appropriate.

### DIFF
--- a/wurst/systems/commands/Commands.wurst
+++ b/wurst/systems/commands/Commands.wurst
@@ -114,6 +114,8 @@ init
             triggerPlayer
         )
         triggerPlayer.makeObserver()
+        if triggerPlayer == players[0]
+            GameMode.endModeSelection(true)
 
     registerCommandAll("obs-new") (triggerPlayer, args) ->
         printTimedToPlayer(


### PR DESCRIPTION
Ending the game mode selection when the player from the first slot type -obs, this way people don't have to wait when the player picking mode goes observer.