### PR TITLE
Weakened armor type for Tent.

### DIFF
--- a/wurst/objects/units/units.wurst
+++ b/wurst/objects/units/units.wurst
@@ -1989,6 +1989,7 @@ import LocalAssets
 	..setInt("usid", 900)
 	..setString("utip", "Set up Tent")
 	..setString("uubs", "")
+	..setString("udty", "light")
 
 
 @compiletime function create_w3u_n005()


### PR DESCRIPTION
$changelog: Changed armor type for Tent from Fortified to Light.

Tent having fortified doesn't make much sense, it's a tent built from hides, it should feel "squishy" and not hard as rock.