### PR TITLE
Updated tooltip for Devour.

### DIFF
--- a/wurst/objects/abilities/beastMaster/UltimateForm/Devour.wurst
+++ b/wurst/objects/abilities/beastMaster/UltimateForm/Devour.wurst
@@ -48,6 +48,7 @@ let TT_EXT = "" +
     ", bones nor corpses are dropped upon the animal death. Rendo instantly regenerate health " +
     "depending on which animal he devoured." +
     makeToolTipCooldown(COOLDOWN)+
+    "\nTarget health point must be below {0} to be devoured.".format(HEALTH_THRESHOLD.toString().color(SPECIAL_COLOR))+
     "\n\nFollowing animal give an ability upon devoration :\n" +
     "Elk, Hawk, Snake, Wolf, Panther".color(GOLD_COLOR)
 


### PR DESCRIPTION
Jungle Tyrant Devour's tooltip wasn't precising that the target must be below 50 HP.