### PR TITLE
Reverted Spirit Ward to have unlimited uses.

### DIFF
--- a/wurst/systems/buildings/SpiritWard.wurst
+++ b/wurst/systems/buildings/SpiritWard.wurst
@@ -45,7 +45,6 @@ init
         if map.has(hero)
             let ward = map.get(hero)
             doAfter(0) ->
-                ward.setLife(0)
                 setWardStoppedReviving(ward)
 
     registerGameStartEvent() ->


### PR DESCRIPTION
$changelog: Reverted Spirit Ward to have unlimited uses.

Not sure why it was changed, but 1 ward per revive is too costly in pub games