### PR TITLE
Fixed check on target for Dream Eater.

### DIFF
--- a/wurst/objects/abilities/mage/hypnotist/DreamEater.wurst
+++ b/wurst/objects/abilities/mage/hypnotist/DreamEater.wurst
@@ -72,8 +72,8 @@ init
 
     // Cancel the casting if the target is not under the effect of Hypnosis.
     EventListener.add(EVENT_PLAYER_UNIT_SPELL_CAST) ->
-        if GetSpellAbilityId() == ABILITY_DREAM_EATER
-            or GetSpellAbilityId() == ABILITY_LEGACY_DREAM_EATER
+        if (GetSpellAbilityId() == ABILITY_DREAM_EATER
+            or GetSpellAbilityId() == ABILITY_LEGACY_DREAM_EATER)
             and not GetSpellTargetUnit().hasAbility(BUFF_ID)
             GetSpellAbilityUnit().abortOrder()
             simError(GetTriggerPlayer(), "Target is not Hypnotized.")


### PR DESCRIPTION
$changelog: Fixed bug where Dream Eater could not be cast on a valid target.