### PR TITLE
Froze order IDs for abilities based on Channel.

### DIFF
--- a/wurst/objects/abilities/Omnicure.wurst
+++ b/wurst/objects/abilities/Omnicure.wurst
@@ -44,6 +44,7 @@ public class Omnicure extends ChannelAbilityPreset
         this.setButtonPositionNormalY(buttonPos.b)
         this.setFollowThroughTime(1, 0.25)
         this.setArtDuration(1, 0)
+        this.presetBaseOrderID(lvl -> "creephealon")
 
 
 @compiletime function createOmnicure()

--- a/wurst/objects/abilities/beastMaster/Pets/PetGrowth.wurst
+++ b/wurst/objects/abilities/beastMaster/Pets/PetGrowth.wurst
@@ -85,6 +85,7 @@ let TOTAL_MAGIC_RESIST = new HashMap<player, int>()
         ..presetTooltipNormalExtended(lvl -> DAMAGE_TOOLTIP_EXT)
         ..setRequirements(UPGD_PET_STATS_ALLOWED.toRawCode())
         ..setRequirementsLevels("1")
+        ..setBaseOrderID(1, "attributemodskill")
 
 @compiletime function createPetArmorAbility() returns ChannelAbilityPreset
     return new ChannelAbilityPreset(ABILITY_PET_ARMOR, 1, true)
@@ -101,6 +102,7 @@ let TOTAL_MAGIC_RESIST = new HashMap<player, int>()
         ..presetTooltipNormalExtended(lvl -> ARMOR_TOOLTIP_EXT)
         ..setRequirements(UPGD_PET_STATS_ALLOWED.toRawCode())
         ..setRequirementsLevels("1")
+        ..setBaseOrderID(1, "auraunholy")
 
 @compiletime function createPetMagicResistAbility() returns ChannelAbilityPreset
     return new ChannelAbilityPreset(ABILITY_PET_MAGIC_RESIST, 1, true)
@@ -116,6 +118,7 @@ let TOTAL_MAGIC_RESIST = new HashMap<player, int>()
         ..presetTooltipNormalExtended(lvl -> MAGIC_RESIST_TOOLTIP_EXT)
         ..setRequirements(UPGD_PET_STATS_ALLOWED.toRawCode())
         ..setRequirementsLevels("1")
+        ..setBaseOrderID(1, "auravampiric")
 
 @compiletime function createPetGrowthAbility() returns ChannelAbilityPreset
     return new ChannelAbilityPreset(ABILITY_GROW_PET, 1, true)
@@ -129,6 +132,7 @@ let TOTAL_MAGIC_RESIST = new HashMap<player, int>()
         ..setManaCost(1, GROWTH_MANACOST)
         ..setTooltipNormal(1, makeToolTipNorm("V", GROWTH_TOOLTIP))
         ..setTooltipNormalExtended(1, GROWTH_TOOLTIP_EXT)
+        ..setBaseOrderID(1, "autodispeloff")
 
 // Increases damage of the pet by 1.
 function increaseDamage(unit caster)

--- a/wurst/objects/abilities/beastMaster/Pets/PetReleasing.wurst
+++ b/wurst/objects/abilities/beastMaster/Pets/PetReleasing.wurst
@@ -35,6 +35,7 @@ function createReleasePetAbility(int newAbilId) returns ChannelAbilityPreset
         ..setTooltipNormalExtended(1, "Releases your pet back into the wild allowing you to tame another. The released pet will run away never to be seen again.")
         ..setRequirements(UPGD_PET_TAMED_TRUE.toRawCode())
         ..setEditorSuffix("(Wurst)")
+        ..setBaseOrderID(1, "autoentangleinstant")
 
 @compiletime function createBaseReleaseSpell() returns ChannelAbilityPreset
     return createReleasePetAbility(ABILITY_PET_RELEASE)

--- a/wurst/objects/abilities/beastMaster/Pets/PetSleep.wurst
+++ b/wurst/objects/abilities/beastMaster/Pets/PetSleep.wurst
@@ -51,6 +51,7 @@ function createPetSleepSpell(int newAbilId) returns ChannelAbilityPreset
         ..setTooltipNormalExtended(1, ABIL_TT)
         ..setRequirements(UPGD_PET_TAMED_TRUE.toRawCode())
         ..setEditorSuffix("(Wurst)")
+        ..setBaseOrderID(1, "avatar")
 
 @compiletime function createBasePetSleepSpell() returns ChannelAbilityPreset
     return createPetSleepSpell(ABILITY_PET_SLEEP)

--- a/wurst/objects/abilities/beastMaster/UltimateForm/Devour.wurst
+++ b/wurst/objects/abilities/beastMaster/UltimateForm/Devour.wurst
@@ -72,6 +72,7 @@ let TT_EXT = "" +
             TargetsAllowed.nonancient
         ))
         ..setAnimationNames("stand")
+        ..setBaseOrderID(1, "curse")
 
 
 function onDevourCast(unit caster, unit target)

--- a/wurst/objects/abilities/beastMaster/UltimateForm/ElkJump.wurst
+++ b/wurst/objects/abilities/beastMaster/UltimateForm/ElkJump.wurst
@@ -48,6 +48,7 @@ let TOOLTIP_EXTENDED = "" +
         ..setCheckDependencies(true)
         ..presetCastRange(lvl -> 99999.)
         ..setRequirements(UPGD_RENDO_ELK_JUMP.toRawCode())
+        ..setBaseOrderID(1, "carrionswarm")
 
 init
     EventListener.onPointCast(ABILITY_RENDO_ELK_JUMP) (unit caster, vec2 targetPos) ->

--- a/wurst/objects/abilities/gatherer/NewItemWarp.wurst
+++ b/wurst/objects/abilities/gatherer/NewItemWarp.wurst
@@ -50,6 +50,7 @@ class ItemWarpSpell extends ChannelAbilityPreset
         this.setButtonPositionNormalX(buttonPos.a)
         this.setButtonPositionNormalY(buttonPos.b)
         this.setFollowThroughTime(1, 0.10)
+        this.setBaseOrderID(1, "fanofknives")
 
 @compiletime function createItemWarpSpell()
     new ItemWarpSpell(ABILITY_ITEM_WARP, "E", new Pair(1, 1))

--- a/wurst/objects/abilities/hunter/tracker/Beacon.wurst
+++ b/wurst/objects/abilities/hunter/tracker/Beacon.wurst
@@ -46,6 +46,7 @@ class QueryTrackingBeacon extends ChannelAbilityPreset
         this.setButtonPositionNormalY(buttonPos.b)
         this.setFollowThroughTime(1, 0.25)
         this.setCasterAttachments(0)
+        this.setBaseOrderID(1, "fanofknives")
 
 
 class HideTrackingBeacon extends ChannelAbilityPreset
@@ -69,6 +70,7 @@ class HideTrackingBeacon extends ChannelAbilityPreset
         this.setFollowThroughTime(1, 0.5)
         this.setArtDuration(1, 0)
         this.setCasterAttachments(0)
+        this.setBaseOrderID(1, "curse")
 
 @compiletime function createBeaconSpells()
     new HideTrackingBeacon (ABILITY_HIDE_BEACON , "R", new Pair(3, 0))

--- a/wurst/objects/abilities/hunter/tracker/Sniff.wurst
+++ b/wurst/objects/abilities/hunter/tracker/Sniff.wurst
@@ -67,6 +67,7 @@ class Sniff extends ChannelAbilityPreset
         this.setCasterAttachmentPoint1("")
         this.setCasterAttachmentPoint("")
         this.setCasterAttachments(0)
+        this.setBaseOrderID(1, "cripple")
 
 @compiletime function createSniff()
     new Sniff(ABILITY_SNIFF, "W", new Pair(1, 0))

--- a/wurst/objects/abilities/mage/dementia/ActivateRunesNew.wurst
+++ b/wurst/objects/abilities/mage/dementia/ActivateRunesNew.wurst
@@ -76,6 +76,7 @@ class ActivateRunes extends ChannelAbilityPreset
         this.setTooltipNormalExtended(1, ACTIVATE_RUNES_TOOLTIP_EXTENDED)
         this.setName(ACTIVATE_RUNES_TOOLTIP_NORM)
         this.setHotkeyNormal(hotkey)
+        this.setBaseOrderID(1, "barkskinon")
 
 @compiletime function createSpells()
     new ActivateRunes(ABILITY_ACTIVATE_RUNE, "A", new Pair(0, 0))

--- a/wurst/objects/abilities/mage/dementia/DarkGateNew.wurst
+++ b/wurst/objects/abilities/mage/dementia/DarkGateNew.wurst
@@ -61,6 +61,7 @@ class DarkGate extends ChannelAbilityPreset
         this.setTooltipNormal(1, makeToolTipNorm(hotkey, TOOLTIP_NORM))
         this.setTooltipNormalExtended(1, TOOLTIP_EXTENDED)
         this.setHotkeyNormal(hotkey)
+        this.setBaseOrderID(1, "immolation")
 
 function createDummyChainlightning()
     new AbilityDefinitionChainLightningcreep(TMP_CHAIN_LIGHTNING_ID)

--- a/wurst/objects/abilities/mage/dementia/DementiaRunesNew.wurst
+++ b/wurst/objects/abilities/mage/dementia/DementiaRunesNew.wurst
@@ -70,27 +70,45 @@ public class DementiaRuneSpell
         this.spellId = spellId
         this.orderId = orderId
 
-class InvokeRune extends ChannelAbilityPreset
-    construct(int newAbilityId, string hotkey, Pair<int, int> buttonPos, string toolTipNorm, string toolTipExt, string icon)
-        super(newAbilityId, 1, true)
-        this.setFollowThroughTime(1, 1)
-        this.setIconNormal(icon)
-        this.setCasterAttachmentPoint1("")
-        this.setTargetAttachmentPoint1("")
-        this.setButtonPositionNormalX(buttonPos.a)
-        this.setButtonPositionNormalY(buttonPos.b)
-        this.setHeroAbility(false)
-        this.setManaCost(1, MANACOST)
-        this.setCooldown(1, COOLDOWN)
-        this.setTooltipNormal(1, makeToolTipNorm(hotkey, toolTipNorm))
-        this.setTooltipNormalExtended(1, toolTipExt)
-        this.setHotkeyNormal(hotkey)
-        this.setName(toolTipNorm)
+function createInvokeRune(int newId) returns ChannelAbilityPreset
+    return new ChannelAbilityPreset(newId, 1, true)
+        ..setFollowThroughTime(1, 1)
+        ..setCasterAttachmentPoint1("")
+        ..setTargetAttachmentPoint1("")
+        ..setHeroAbility(false)
+        ..setManaCost(1, MANACOST)
+        ..setCooldown(1, COOLDOWN)
 
-@compiletime function createRuneSpells()
-    new InvokeRune(ABILITY_INVOKE_RUNE_1, "W", new Pair(1, 0), TOOLTIP_NORM_NEL, TOOLTIP_EXT_NEL, ICON_NEL)
-    new InvokeRune(ABILITY_INVOKE_RUNE_2, "E", new Pair(2, 0), TOOLTIP_NORM_KA , TOOLTIP_EXT_KA , ICON_KA)
-    new InvokeRune(ABILITY_INVOKE_RUNE_3, "R", new Pair(3, 0), TOOLTIP_NORM_LEZ, TOOLTIP_EXT_LEZ, ICON_LEZ)
+@compiletime function createNelRune()
+    createInvokeRune(ABILITY_INVOKE_RUNE_1)
+        ..presetButtonPosNormal(1, 0)
+        ..setTooltipNormal(1, makeToolTipNorm("W", TOOLTIP_NORM_NEL))
+        ..setTooltipNormalExtended(1, TOOLTIP_EXT_NEL)
+        ..setHotkeyNormal("W")
+        ..setName(TOOLTIP_NORM_NEL)
+        ..setIconNormal(ICON_NEL)
+        ..setBaseOrderID(1, "ambush")
+
+@compiletime function createKaRune()
+    createInvokeRune(ABILITY_INVOKE_RUNE_2)
+        ..presetButtonPosNormal(2, 0)
+        ..setTooltipNormal(1, makeToolTipNorm("E", TOOLTIP_NORM_KA))
+        ..setTooltipNormalExtended(1, TOOLTIP_EXT_KA)
+        ..setHotkeyNormal("E")
+        ..setName(TOOLTIP_NORM_KA)
+        ..setIconNormal(ICON_KA)
+        ..setBaseOrderID(1, "ancestralspirit")
+
+@compiletime function createLezRune()
+    createInvokeRune(ABILITY_INVOKE_RUNE_3)
+        ..presetButtonPosNormal(3, 0)
+        ..setTooltipNormal(1, makeToolTipNorm("R", TOOLTIP_NORM_LEZ))
+        ..setTooltipNormalExtended(1, TOOLTIP_EXT_LEZ)
+        ..setHotkeyNormal("R")
+        ..setName(TOOLTIP_NORM_LEZ)
+        ..setIconNormal(ICON_LEZ)
+        ..setBaseOrderID(1, "ancestralspirittarget")
+
 
 class DementiaRune
     DementiaRunesInstance instance

--- a/wurst/objects/abilities/mage/elementalist/Brambles.wurst
+++ b/wurst/objects/abilities/mage/elementalist/Brambles.wurst
@@ -136,6 +136,7 @@ class Brambles extends ChannelAbilityPreset
         this.setManaCost(1, MANACOST)
         this.setTargetType(1, 3)
         this.setCastRange(1, RANGE)
+        this.setBaseOrderID(1, "carrionswarm")
 
 @compiletime function createBrambles()
     new Brambles(ABILITY_ID, "S", new Pair(1, 1))

--- a/wurst/objects/abilities/mage/elementalist/EarthGuardian.wurst
+++ b/wurst/objects/abilities/mage/elementalist/EarthGuardian.wurst
@@ -113,6 +113,7 @@ class EarthGuardian extends ChannelAbilityPreset
         this.setFollowThroughTime(1, CHANNEL_DURATION)
         this.setCooldown(1, COOLDOWN)
         this.setManaCost(1, MANACOST)
+        this.setBaseOrderID(1, "auravampiric")
 
 @compiletime function createEarthGuardian()
     new EarthGuardian(ABILITY_ID, "W", new Pair(1, 0))

--- a/wurst/objects/abilities/mage/elementalist/FrostBlast.wurst
+++ b/wurst/objects/abilities/mage/elementalist/FrostBlast.wurst
@@ -95,7 +95,7 @@ class FrostBlast extends ChannelAbilityPreset
         this.setManaCost(1, MANACOST)
         this.setTargetType(1, 3)
         this.setCastRange(1, MISSILE_SPEED * MISSILE_LIFETIME)
-        this.setBaseOrderID(1, "blink")
+        this.setBaseOrderID(1, "freezingbreath")
 
 @compiletime function createFrostBlast()
     new FrostBlast(ABILITY_ID, "E", new Pair(2, 0))

--- a/wurst/objects/abilities/mage/elementalist/Meditate.wurst
+++ b/wurst/objects/abilities/mage/elementalist/Meditate.wurst
@@ -67,6 +67,7 @@ function constructMeditate(int newAbilityId, string hotkey, Pair<int, int> butto
         ..setOptions(1, 1)
         ..setCooldown(1, COOLDOWN)
         ..setManaCost(1, MANACOST)
+        ..setBaseOrderID(1, "auraunholy")
 
 class MeditateInstance
     // The collection of all units currently under the effects of Meditate.

--- a/wurst/objects/abilities/mage/hypnotist/DepressionOrb.wurst
+++ b/wurst/objects/abilities/mage/hypnotist/DepressionOrb.wurst
@@ -54,6 +54,7 @@ class DepressionOrb extends ChannelAbilityPreset
         this.setHeroAbility(false)
         this.setTargetAttachmentPoint1("")
         this.setCasterAttachmentPoint1("")
+        this.setBaseOrderID(1, "blink")
 
 @compiletime function createDepressionOrb()
     new DepressionOrb(ABILITY_DEPRESSION_ORB, "R", new Pair(3, 0))

--- a/wurst/objects/abilities/mage/hypnotist/Seizures.wurst
+++ b/wurst/objects/abilities/mage/hypnotist/Seizures.wurst
@@ -59,6 +59,7 @@ class Seizures extends ChannelAbilityPreset
         this.setAnimationNames(ANIMATION_NAME)
         this.setArtTarget(Abilities.boltImpact)
         this.setTargetsAllowed(1, TARGET_ALLOWED)
+        this.setBaseOrderID(1, "chainlightning")
 
 @compiletime function createSeizures()
     new Seizures(ABILITY_SEIZURES, "S", new Pair(1, 1))

--- a/wurst/objects/abilities/mage/hypnotist/StupefyField.wurst
+++ b/wurst/objects/abilities/mage/hypnotist/StupefyField.wurst
@@ -75,6 +75,7 @@ class StupefyField extends ChannelAbilityPreset
         this.setArtTarget(Abilities.flameStrikeTarget)
         this.setEffects(1, Abilities.flameStrikeTarget)
         this.setArtCaster(commaList(Abilities.voodooAuraTarget, Abilities.flameStrikeTarget))
+        this.setBaseOrderID(1, "taunt")
 
 @compiletime function createStupefyField()
     new StupefyField(ABILITY_STUPEFY, "F", new Pair(3, 1))

--- a/wurst/objects/abilities/mage/unsub/ReduceFood.wurst
+++ b/wurst/objects/abilities/mage/unsub/ReduceFood.wurst
@@ -42,7 +42,7 @@ class ReduceFood extends ChannelAbilityPreset
         this.setTooltipNormalExtended(1, TOOLTIP_EXTENDED)
         this.setTooltipNormal(1, makeToolTipNorm(hotkey, TOOLTIP))
         this.setHotkeyNormal(hotkey)
-        this.setBaseOrderID(1, "shockwave")
+        this.setBaseOrderID(1, "curse")
         this.setButtonPositionNormalX(buttonPos.a)
         this.setButtonPositionNormalX(buttonPos.b)
 

--- a/wurst/objects/abilities/priest/booster/AngelicElemental.wurst
+++ b/wurst/objects/abilities/priest/booster/AngelicElemental.wurst
@@ -71,6 +71,7 @@ class AngelicElemental extends ChannelAbilityPreset
         this.presetTooltipNormalExtended(lvl -> TOOLTIP_EXT)
         this.setButtonPositionNormalX(buttonPos.a)
         this.setButtonPositionNormalY(buttonPos.b)
+        this.setBaseOrderID(1, "blink")
 
 @compiletime function createAngelicElemental()
     new AngelicElemental(ABILITY_ANGELIC_ELEMENTAL, "S", new Pair(2, 1))

--- a/wurst/objects/abilities/priest/sage/MaximumFervor.wurst
+++ b/wurst/objects/abilities/priest/sage/MaximumFervor.wurst
@@ -79,6 +79,7 @@ class MaximumFervor extends ChannelAbilityPreset
         this.setArtTarget(Abilities.brilliance)
         this.setArtCaster("")
         this.setCasterAttachmentPoint("")
+        this.setBaseOrderID(1, "taunt")
 
 // class MaximumFervor extends AbilityDefinitionRoar
 //     construct(int newAbilityId, string hotkey, Pair<int, int> buttonPos)

--- a/wurst/objects/abilities/priest/unsub/AntiMagic.wurst
+++ b/wurst/objects/abilities/priest/unsub/AntiMagic.wurst
@@ -70,7 +70,7 @@ class AntiMagicAoEDummy extends ChannelAbilityPreset
         this.presetTargetTypes(Targettype.POINT)
         this.setHotkeyNormal(hotkey)
         this.setName(TOOLTIP_NORM)
-        this.setBaseOrderID(1, "antimagicshell")
+        this.setBaseOrderID(1, "devourmagic")
         this.presetTooltipNormal(lvl -> makeToolTipNorm(hotkey, TOOLTIP_NORM))
         this.presetTooltipNormalExtended(lvl -> TOOLTIP_EXTENDED)
         this.setIconNormal(Icons.bTNAntiMagicShell)

--- a/wurst/objects/abilities/scout/Reveal.wurst
+++ b/wurst/objects/abilities/scout/Reveal.wurst
@@ -75,6 +75,7 @@ class Reveal extends ChannelAbilityPreset
         this.setButtonPositionNormalX(buttonPos.a)
         this.setButtonPositionNormalY(buttonPos.b)
         this.presetFollowThroughTime(lvl -> CAST_TIME)
+        this.setBaseOrderID(1, "unrobogoblin")
 
 class GreaterReveal extends Reveal
     construct(int newAbilityId, string hotkey, Pair<int, int> buttonPos)
@@ -94,6 +95,7 @@ class ChainReveal extends Reveal
         this.presetTooltipNormalExtended(lvl -> CHAIN_REVEAL_TOOLTIP_EXTENDED)
         this.setTooltipLearn(makeToolTipLearn(TOOLTIP_NORM))
         this.setTooltipLearnExtended(CHAIN_REVEAL_TOOLTIP_EXTENDED)
+        this.setBaseOrderID(1, "voodoo")
 
 @compiletime function createReveal()
     new Reveal(ABILITY_REVEAL_ID, "E", new Pair(1, 1))

--- a/wurst/objects/abilities/scout/ScoutRadars.wurst
+++ b/wurst/objects/abilities/scout/ScoutRadars.wurst
@@ -66,8 +66,9 @@ public class RadarSpell
     let btnPositionY = 0
     let cooldown = COOLDOWN
     let manaCost = 10
+    let baseOrderId = "channel"
 
-    construct(string unitToPing, string toolTip, string iconPath, int id, int btnX, int btnY, string hotkey, int manaCost, string color)
+    construct(string unitToPing, string toolTip, string iconPath, int id, int btnX, int btnY, string hotkey, int manaCost, string color, string baseOrderId)
         this.name = GENERAL_COLOR.toColorString()+"[" + SPECIAL_COLOR.toColorString() + hotkey + GENERAL_COLOR.toColorString() + "] - " + this.name + color + unitToPing + "|r"
         this.toolTip += color+unitToPing + "|r surrounding your position." + toolTip
         this.iconPath += iconPath
@@ -76,6 +77,7 @@ public class RadarSpell
         this.btnPositionY = btnY
         this.hotkey = hotkey
         this.manaCost = manaCost
+        this.baseOrderId = baseOrderId
 
     function buildSpell()
         new ChannelAbilityPreset(id, 1, true)
@@ -95,20 +97,21 @@ public class RadarSpell
             ..presetCooldown(lvl -> cooldown)
             ..presetManaCost(lvl -> manaCost)
             ..presetFollowThroughTime(lvl -> 1.)
+            ..presetBaseOrderID(lvl -> baseOrderId)
 
 function getRadarSpells() returns LinkedList<RadarSpell>
     return asList(
         //Unsub Scout Radar Spell
-        new RadarSpell("Elk|r"+GENERAL_COLOR.toColorString()+" and "+COLOR_RED.toColorString()+"Hostile Units" , TOOL_TIP_COOLDOWN, "BTNSpy.blp" , ABILITY_PING_ENEMY, 2, 1, "R", 0, COLOR_GREEN.toColorString()  ),
-        new RadarSpell("Elk|r"+GENERAL_COLOR.toColorString()+" and "+COLOR_RED.toColorString()+"Hostile Units" , TOOL_TIP_COOLDOWN, "BTNSpy.blp" , ABILITY_SPY_PING_ENEMY, 2, 1, "A", 0, COLOR_GREEN.toColorString()  ),
+        new RadarSpell("Elk|r"+GENERAL_COLOR.toColorString()+" and "+COLOR_RED.toColorString()+"Hostile Units" , TOOL_TIP_COOLDOWN, "BTNSpy.blp" , ABILITY_PING_ENEMY, 2, 1, "R", 0, COLOR_GREEN.toColorString(), "robogoblin"  ),
+        new RadarSpell("Elk|r"+GENERAL_COLOR.toColorString()+" and "+COLOR_RED.toColorString()+"Hostile Units" , TOOL_TIP_COOLDOWN, "BTNSpy.blp" , ABILITY_SPY_PING_ENEMY, 2, 1, "A", 0, COLOR_GREEN.toColorString(), "stoneform"),
 
         //Advanced Radar Spells
-        new RadarSpell("Elk"              , TOOL_TIP_COOLDOWN, "BTNSpy.blp" , ABILITY_PING_ELK             , 0, 0, "Q", MANACOST, COLOR_GREEN .toColorString() ),
-        new RadarSpell("Hawk"             , TOOL_TIP_COOLDOWN, "BTNSpy.blp" , ABILITY_PING_HAWK            , 0, 0, "W", MANACOST, COLOR_TEAL  .toColorString() ),
-        new RadarSpell("Hostile Animals"  , TOOL_TIP_COOLDOWN, "BTNSpy.blp" , ABILITY_PING_HOSTILE_ANIMALS , 0, 0, "E", MANACOST, COLOR_RED   .toColorString() ),
-        new RadarSpell("Hostile Building" , TOOL_TIP_COOLDOWN, "BTNSpy.blp" , ABILITY_PING_BUILDING        , 0, 0, "R", MANACOST, COLOR_ORANGE.toColorString() ),
-        new RadarSpell("Trolls"           , TOOL_TIP_COOLDOWN, "BTNSpy.blp" , ABILITY_PING_TROLL           , 0, 0, "A", MANACOST, COLOR_RED   .toColorString() ),
-        new RadarSpell("Living Clay"      , TOOL_TIP_COOLDOWN, "BTNSpy.blp" , ABILITY_PING_LIVING_CLAY     , 0, 0, "S", MANACOST, COLOR_PINK  .toColorString() )
+        new RadarSpell("Elk"              , TOOL_TIP_COOLDOWN, "BTNSpy.blp" , ABILITY_PING_ELK             , 0, 0, "Q", MANACOST, COLOR_GREEN .toColorString(), "militia" ),
+        new RadarSpell("Hawk"             , TOOL_TIP_COOLDOWN, "BTNSpy.blp" , ABILITY_PING_HAWK            , 0, 0, "W", MANACOST, COLOR_TEAL  .toColorString(), "militiaconvert" ),
+        new RadarSpell("Hostile Animals"  , TOOL_TIP_COOLDOWN, "BTNSpy.blp" , ABILITY_PING_HOSTILE_ANIMALS , 0, 0, "E", MANACOST, COLOR_RED   .toColorString(), "militiaoff" ),
+        new RadarSpell("Hostile Building" , TOOL_TIP_COOLDOWN, "BTNSpy.blp" , ABILITY_PING_BUILDING        , 0, 0, "R", MANACOST, COLOR_ORANGE.toColorString(), "militiaunconvert" ),
+        new RadarSpell("Trolls"           , TOOL_TIP_COOLDOWN, "BTNSpy.blp" , ABILITY_PING_TROLL           , 0, 0, "A", MANACOST, COLOR_RED   .toColorString(), "mirrorimage" ),
+        new RadarSpell("Living Clay"      , TOOL_TIP_COOLDOWN, "BTNSpy.blp" , ABILITY_PING_LIVING_CLAY     , 0, 0, "S", MANACOST, COLOR_PINK  .toColorString(), "nightelfbuild" )
     )
 
 function onCast(LinkedList<int> unitId, real red, real green, real blue)

--- a/wurst/objects/abilities/scout/Trap.wurst
+++ b/wurst/objects/abilities/scout/Trap.wurst
@@ -179,6 +179,7 @@ class PlaceTrapSpell extends ChannelAbilityPreset
         this.presetOption(Option.TARGETIMAGE, true)
         this.setCastRange(1, TRAP_CAST_RANGE)
         this.setAnimationNames(animationName)
+        this.setBaseOrderID(1, "devourmagic")
 
 class PlaceTrackTrapSpell extends PlaceTrapSpell
     construct(int newAbilityId, string hotkey, Pair<int, int> buttonPos)

--- a/wurst/objects/abilities/scout/WardArea.wurst
+++ b/wurst/objects/abilities/scout/WardArea.wurst
@@ -58,6 +58,7 @@ class WardAreaSpell extends ChannelAbilityPreset
         this.setButtonPositionNormalY(buttonPos.b)
         this.presetFollowThroughTime(lvl -> CASTTIME)
         this.setAnimationNames("spell,throw")
+        this.setBaseOrderID(1, "impale")
 
 class ObserverWardAreaSpell extends WardAreaSpell
     construct(int newAbilityId, string hotkey, Pair<int, int> buttonPos, int lvls)


### PR DESCRIPTION
I set the base order Id for all channel ability preset that were still relying on the automatic orderId attribution from the ChannelAbilityPreset class.

The issue was that the automatic setting could result in a conflict between spells and those would not cast properly.
