### PR TITLE
Removed spammy print at compiletime.

### DIFF
--- a/wurst/config/OrderStringFactory_config.wurst
+++ b/wurst/config/OrderStringFactory_config.wurst
@@ -47,5 +47,4 @@ let banned = new HashSet<string>()..add(
 
 
 @config function isOrderBanned(string _order) returns boolean
-    print("banning " + _order + ": " + banned.has(_order).toString())
     return banned.has(_order)


### PR DESCRIPTION
We're no longer using the order string factory and this doesn't help much even if we were.