### PR TITLE
Fixed visibility for text tag for Mana Burn.

### DIFF
--- a/wurst/utils/ManaBurn.wurst
+++ b/wurst/utils/ManaBurn.wurst
@@ -1,5 +1,7 @@
 package ManaBurn
 
+import initlater PlayerExtensions
+
 public function burnMana(unit target, real damage)
     // Exit if the unit does not hava mana.
     if target.getMaxMana() == 0
@@ -20,4 +22,4 @@ public function burnMana(unit target, real damage)
         ..setVisibility(true)
         ..setFadepoint(2.0)
         ..setLifespan(5.0)
-        ..setPermanent(false)
+        ..setPermanent(localPlayer.hasVisibility(target))


### PR DESCRIPTION
$changelog: Fixed bug where players could see mana burn text on targets without line of sight.