### PR TITLE
Fixing breaking import.

### DIFF
--- a/wurst/objects/items/Armory/SpearsDefinition.wurst
+++ b/wurst/objects/items/Armory/SpearsDefinition.wurst
@@ -7,6 +7,10 @@ import BuffObjEditing
 import AbilityObjEditing
 
 // Local imports:
+// TODO: Although this import is not used, it is needed to avoid breaking the
+//       underlying hashtables used elsewhere. It's not clear if this is due to
+//       the initialization order of objects or just an odd behavior of the
+//       compiler. This should be reinvestigated once #593 is complete.
 import Items
 import LocalAssets
 import ToolTipsUtils

--- a/wurst/objects/items/Armory/SpearsDefinition.wurst
+++ b/wurst/objects/items/Armory/SpearsDefinition.wurst
@@ -11,6 +11,7 @@ import AbilityObjEditing
 //       underlying hashtables used elsewhere. It's not clear if this is due to
 //       the initialization order of objects or just an odd behavior of the
 //       compiler. This should be reinvestigated once #593 is complete.
+import Spears
 import Items
 import LocalAssets
 import ToolTipsUtils


### PR DESCRIPTION
Although this import is not used, unrelated hash maps appear to break without it, but only in games with multiple players. In my test, I specifically saw the hash map in `Skins` break, where a retrieved skins for a unit was not null but also not a valid object.

This was broken in #701 and this is a revert of that change.