### PR TITLE
Fixed decimal rounding when checking death due to energy.

### DIFF
--- a/wurst/systems/core/Experience.wurst
+++ b/wurst/systems/core/Experience.wurst
@@ -120,7 +120,7 @@ function performExperienceGain()
 
 function checkStatDeath(unit target)
     // Exit if no work is required.
-    if not target.isAlive() or (target.getMana() > 0 and target.getHeat() > 0)
+    if not target.isAlive() or (target.getMana() >= 1 and target.getHeat() >= 1)
         return
 
     // Cache the relevant properties of the target.


### PR DESCRIPTION
$changelog: Fixed bug where trolls would stay alive at 0 energy.

MasterHealer brillance aura regenerate 0.33 mana per second, but the regeneration actually happen every ANIMATION_PERIOD (0.03), mana is a real value, I ran a test, did -mp 0 on MasterHealer but he still had 0.007 mana upon this check due to brillance aura regeneration, therefore he doesn't die with 0 mana being displayed in the portrait. 

I changed this check 10 month ago, I don't remember why, it used to do a proper check.