### PR TITLE
Restored model fix for Mud Hut.

### DIFF
--- a/wurst/objects/units/Buildings/Huts.wurst
+++ b/wurst/objects/units/Buildings/Huts.wurst
@@ -74,7 +74,7 @@ function createHut(int unitId) returns BuildingDefinition
     return createHut(UNIT_MUD_HUT)
         ..setIconGameInterface(Icons.bTNGoldmine)
         ..setTintingColorBlue(0)
-        ..setModelFile(Doodads.igloo)
+        ..setModelFile(LocalBuildings.iglooFixed)
         ..setTintingColorGreen(75)
         ..setName("Mud Hut")
         ..setTintingColorRed(150)


### PR DESCRIPTION
Dropped when merging #585 after being added in #657. Not going to include this in the changelog again as it was a minor bug that only briefly reappeared.