### PR TITLE
Fixed bug where Bonfire failed to heat nearby units.

### DIFF
--- a/wurst/extensions/UnitExtensions.wurst
+++ b/wurst/extensions/UnitExtensions.wurst
@@ -115,15 +115,13 @@ public function unit.getHeat() returns int
     return this.getOwner().getGold()
 
 public function unit.setHeat(int heat)
-    this.getOwner().setGold(heat)
+    this.getOwner().setGold(heat.clamp(0, gameConfig.getMaxHeat()))
 
-public function unit.addHeat(int heat)
-    let owner = this.getOwner()
-    owner.setGold(min(owner.getGold() + heat, gameConfig.getMaxHeat()))
+public function unit.addHeat(int delta)
+    this.setHeat(this.getOwner().getGold() + delta)
 
 public function unit.subHeat(int heat)
-    let owner = this.getOwner()
-    owner.setGold(max(owner.getGold() - heat, 0))
+    this.addHeat(-heat)
 
 public function unit.getItemMatching(Predicate<item> predicate) returns item
     let inventorySize = this.inventorySize()

--- a/wurst/objects/abilities/Heat.wurst
+++ b/wurst/objects/abilities/Heat.wurst
@@ -86,14 +86,13 @@ function createUnsafeHeat(int abilId) returns AbilityDefinitionTornadoDamage
         ..setLevels(1)
         ..setName("Bonfire")
         ..setArtTarget("")
-        ..setTargetsAllowed(1, commaList(
-            TargetsAllowed.enemies,
-            TargetsAllowed.hero,
-            TargetsAllowed.player_t
+        ..presetTargetsAllowed(
+            lvl -> commaList(
+                TargetsAllowed.hero
             )
         )
-        ..setTooltipNormal(1, "Bonfire")
-        ..setTooltipNormalExtended(1, "Gives heat to nearby units")
+        ..presetTooltipNormal(lvl -> "Bonfire")
+        ..presetTooltipNormalExtended(lvl -> "Gives heat to nearby units")
         ..setEditorSuffix("(Wurst)")
 
 function createHeatCast(int abilId) returns AbilityDefinitionFaerieFire


### PR DESCRIPTION
$changelog: Fixed bug where Bonfire failed to heat nearby units.

This is caused by the `TargetsAllowed.player_t`, which restricts targets to the units of the same player as the caster. There isn't a need to restrict the targets much, as the buff is only checked for trolls in `StatLoss` anyway. Filtering for targets is only useful for avoiding confusing players by showing the buff on irrelevant units.