### PR TITLE
Buffed mana drain on Dark Spear.

### DIFF
--- a/wurst/objects/items/Armory/SpearsDefinition.wurst
+++ b/wurst/objects/items/Armory/SpearsDefinition.wurst
@@ -26,7 +26,7 @@ let SPEAR_DMG = 40.
 let IRON_DMG  = 70.
 let STEEL_DMG = 100.
 let DARK_DMG  = 40.
-let DARK_MANA_BURN = 30.
+let DARK_MANA_BURN = 0.4
 
 //[Initial, Decaying]
 let POISON_DMG  = [10., 6. ]
@@ -60,7 +60,7 @@ let TT_COMMON   = "" +
     "Has {1} chance of being recoverable."
 
 let TT_DARK_PRE_FORMAT = "" +
-    "A spear with one use. Deals {0} damage and zaps {1}% of current energy on hit. "+
+    "A spear with one use. Deals {0} damage and zaps 10 plus {1} of current energy on hit. "+
     "Not recoverable"
 
 let TT_PS   = "" + "Hurls a poisoned spear at a target enemy unit, "+

--- a/wurst/objects/items/Spears.wurst
+++ b/wurst/objects/items/Spears.wurst
@@ -27,7 +27,8 @@ public let POISON_RESPAWN_CHANCE  = 0.5
 public let RPOISON_RESPAWN_CHANCE = 0.5
 public let UPOISON_RESPAWN_CHANCE = 0.5
 
-let DARK_SPEAR_MANA_BURN_PERCENTAGE = .30
+let DARK_SPEAR_MANA_BURN_PERCENTAGE = .40
+let DARK_SPEAR_MIN_MANA_BURN        = 10.
 
 @compiletime function createAbilSpearHitDetection()
     new AbilityDefinitionThunderBoltCreep(ABILITY_SPEAR_HIT_DETECTION)
@@ -91,7 +92,8 @@ function onSpearImpact(unit caster, unit target, SpearType spearType)
             spawnItemChance(POISON_RESPAWN_CHANCE, ITEM_POISON_SPEAR, target.getPos())
         case DarkSpear
             spawnItemChance(DARK_RESPAWN_CHANCE, ITEM_DARK_SPEAR, target.getPos())
-            let burnAmount = target.getMana() * DARK_SPEAR_MANA_BURN_PERCENTAGE
+            let burnAmount = DARK_SPEAR_MIN_MANA_BURN +
+                (target.getMana() * DARK_SPEAR_MANA_BURN_PERCENTAGE)
 
             // Perform the mana reduction.
             caster.drainMana(target, burnAmount)

--- a/wurst/systems/crafting/QuickMakeToolTips.wurst
+++ b/wurst/systems/crafting/QuickMakeToolTips.wurst
@@ -146,7 +146,7 @@ public let MAGE_MASHER_RECIPE = "a Mage Masher. " + TT_MM + "\n\n1x "+STICK+"/"+
 public let SPEAR_RECIPE       = "a Spear. Deals 40 damage on target, has 60% chance of being recoverable :\n\n1x "                             +STICK+"/"+BONE+" + 1x "+STONE
 public let IRON_SPEAR_RECIPE  = "a Iron Spear. Deals 70 damage on target, has 60% chance of being recoverable :\n\n1x "                        +STICK+"/"+BONE+" + 1x "+IRON
 public let STEEL_SPEAR_RECIPE = "a Steel Spear. Deals 100 damage on target, has 60% chance of being recoverable :\n\n1x "                      +STICK+"/"+BONE+" + 1x "+STEEL
-public let DARK_SPEAR_RECIPE  = "a Dark Spear. Deals 40 damage and will zap 30% of the target's current energy :\n\n1x "+DARKNESS + "1x "+STICK+"/"+BONE
+public let DARK_SPEAR_RECIPE  = "a Dark Spear. Deals 40 damage and will zap 10 plus 40% of the target's current energy :\n\n1x "+DARKNESS + "1x "+STICK+"/"+BONE
 
 public let SHIELD_RECIPE       = BASIC_SHIELD_TOOLTIP +"\n\n1x " +ELK_HIDE +" + 2x " +STICK
 public let BONE_SHIELD_RECIPE  = BONE_SHIELD_TOOLTIP  +"\n\n1x " +SHIELD   +" + 5x " +BONE


### PR DESCRIPTION
$changelog: Updated Dark Spear mana drain from 30% of current mana to 10 plus 40% of current mana.

Dark spear had been nerfed in #496 to the point where it was nearly useless to answer "aggressive" nerf suggestions.
It has been a year now and community has asked for a buff.
Made this change following discussion from the discord.