### PR TITLE
Quickfix to avoid error from commaList ambigeous definition

### DIFF
--- a/wurst/objects/units/Buildings/NeutralBuildings.wurst
+++ b/wurst/objects/units/Buildings/NeutralBuildings.wurst
@@ -2,8 +2,8 @@ package NeutralBuildings
 
 // Standard lib Imports:
 import Assets
-import ChannelAbilityPreset
 import LinkedList
+import UnitObjEditing
 
 // Local Imports:
 import LocalObjectIDs
@@ -118,18 +118,21 @@ function createBushNeutralBuilding(int unitId) returns BuildingDefinition
 
     createBushNeutralBuilding(UNIT_THIEFS_BUSH)
         ..setNormalAbilities(commaList(
+            asList(
             LocalAbilityIds.inventoryBuilding,
             AbilityIds.invulnerable
+            )
         ))
         ..setModelFile(Doodads.outland_Plant6)
         ..setName("Thief's Bush")
 
     createBushNeutralBuilding(UNIT_SCOUTS_BUSH)
         ..setNormalAbilities(commaList(
+            asList(
             AbilityIds.ghost,
             LocalAbilityIds.inventoryBuilding,
             AbilityIds.invulnerable
-            )
+            ))
         )
         ..setModelFile(Doodads.felwoodCatTail)
         ..setName("Scout's Bush")


### PR DESCRIPTION
![21-07-22-22-15-59](https://user-images.githubusercontent.com/7768858/126845424-6132bea3-640e-43f3-b523-1f6b15526c0b.jpg)

A quick fix to avoid this error in case you want to work on something else, don't know how it should properly be fixed.

Stdlib added a `commaList(LinkedList<int> ids)` which conflict with the `commaList(vararg LinkedList<int> lists)` defined [here](https://github.com/island-troll-tribes/island-troll-tribes/blob/d792e4dbef25df39a6512957058e604bcf687f1d/wurst/utils/ObjEditingUtils.wurst#L9)