### PR TITLE
Added spell resistance to Mammoth and Disco Duck.

### DIFF
--- a/wurst/objects/abilities/BossAbilities.wurst
+++ b/wurst/objects/abilities/BossAbilities.wurst
@@ -111,6 +111,6 @@ public let ABILITY_SPELL_DMG_REDUCTION_DUMMY_BUFF = compiletime(
 // Used by bosses
 @compiletime function createBossSpellResistance() returns AbilityDefinitionRunedBracers
     return new AbilityDefinitionRunedBracers(ABILITY_SPELL_DMG_REDUCTION)
-        ..setDamageReduction(1, 0.3)
+        ..setDamageReduction(1, SPELL_RESISTANCE)
         ..setName("Boss Spell Resistance")
         ..setEditorSuffix("(modded)")

--- a/wurst/objects/abilities/BossAbilities.wurst
+++ b/wurst/objects/abilities/BossAbilities.wurst
@@ -54,12 +54,14 @@ let ACID_BREATH_DURATION = 10.
 let DMG_REDUCED = 17.
 let CHANCE_TO_REDUCE = 0.5
 
-public let ABILITY_HARDENED_SKIN_DUMMY_BUFF = compiletime(createDummyBuffObject(
-    "Damage Reduction".color(COLOR_GREEN),
-    "This unit has a hardened skin; has {0} chance to incoming reduce damage by {1}"
-    .format(CHANCE_TO_REDUCE.toToolTipGreen(), DMG_REDUCED.toToolTipRed()),
-    Icons.bTNHardenedSkin)
-    .abilId)
+public let ABILITY_HARDENED_SKIN_DUMMY_BUFF = compiletime(
+    createDummyBuffObject(
+        "Damage Reduction".color(COLOR_GREEN),
+        "This unit has hardened skin: granting it a {0} chance to incoming reduce damage by {1}."
+        .format(CHANCE_TO_REDUCE.toToolTipGreen(), DMG_REDUCED.toToolTipRed()),
+        Icons.bTNHardenedSkin
+    ).abilId
+)
 
 // Used by bosses
 @compiletime function createBossHardenedSkin() returns AbilityDefinitionHardenedSkin
@@ -97,12 +99,14 @@ public let ABILITY_HARDENED_SKIN_DUMMY_BUFF = compiletime(createDummyBuffObject(
 
 let SPELL_RESISTANCE = 0.3
 
-public let ABILITY_SPELL_DMG_REDUCTION_DUMMY_BUFF = compiletime(createDummyBuffObject(
-    "Spell Damage Reduction".color(COLOR_GREEN),
-    "This unit has a thick skin; reduces spell damage by {0}"
-    .format(SPELL_RESISTANCE.toToolTipGreen()),
-    Icons.bTNThickFur)
-    .abilId)
+public let ABILITY_SPELL_DMG_REDUCTION_DUMMY_BUFF = compiletime(
+    createDummyBuffObject(
+        "Spell Damage Reduction".color(COLOR_GREEN),
+        "This unit has thick skin: reducing all spell damage dealt to it by {0}."
+        .format(SPELL_RESISTANCE.toToolTipGreen()),
+        Icons.bTNThickFur
+    ).abilId
+)
 
 // Used by bosses
 @compiletime function createBossSpellResistance() returns AbilityDefinitionRunedBracers

--- a/wurst/objects/abilities/BossAbilities.wurst
+++ b/wurst/objects/abilities/BossAbilities.wurst
@@ -10,25 +10,37 @@ import Assets
 // Local Imports:
 import LocalObjectIDs
 import LocalAssets
+import ColorUtils
+import ToolTipsUtils
 
+
+let ACID_BREATH_DMG_SEC = 20.
+let ACID_BREATH_DURATION = 10.
 
 @compiletime function createBreathOfAcid() returns AbilityDefinitionBreathofFrostCreep
     let buffId = BUFF_ID_GEN.next()
     new BuffDefinition(buffId, BuffIds.breathofFrost)
         ..setIconNormal(1, Icons.bTNCorrosiveBreath)
         ..setTooltipNormal("Poisonous Breath")
-        ..setTooltipNormalExtended("This unit was hit by the Breath of a Hydra and will take damage over time.")
+        ..setTooltipNormalExtended(
+            "This unit was hit by the Breath of a Hydra and will take "+
+            "{0} damage over {1} seconds.".format(
+                ACID_BREATH_DMG_SEC.toToolTipRed(),
+                ACID_BREATH_DURATION.toToolTipLightBlue()
+                )
+            )
         ..setName("Poisonous Breath")
         ..setArtTarget(Abilities.chimaeraAcidTargetArt)
 
     return new AbilityDefinitionBreathofFrostCreep(ABILITY_HYDRA_BREATH)
         ..setIconNormal(Icons.bTNCorrosiveBreath)
         ..setBuffs(1, buffId.toRawCode())
-        ..setDamagePerSecond(1, 20.0)
-        ..setDurationNormal(1, 10.0)
-        ..setDurationHero(1, 10.0)
+        ..setDamagePerSecond(1, ACID_BREATH_DMG_SEC)
+        ..setDurationNormal(1, ACID_BREATH_DURATION)
+        ..setDurationHero(1, ACID_BREATH_DURATION)
         ..setMissileArt(LocalAbilities.breatOfAcidMissile)
         ..setName("Breath of Hydra")
+        ..setTooltipNormal(1, "Breath of Hydra")
         ..setCastRange(1, 800.0)
         ..setTargetsAllowed(1, "terrain")
 
@@ -39,13 +51,23 @@ import LocalAssets
         ..setItemAbility(true)
         ..setName("Item Crit")
 
+let DMG_REDUCED = 17.
+let CHANCE_TO_REDUCE = 0.5
+
+public let ABILITY_HARDENED_SKIN_DUMMY_BUFF = compiletime(createDummyBuffObject(
+    "Damage Reduction".color(COLOR_GREEN),
+    "This unit has a hardened skin; has {0} chance to incoming reduce damage by {1}"
+    .format(CHANCE_TO_REDUCE.toToolTipGreen(), DMG_REDUCED.toToolTipRed()),
+    Icons.bTNHardenedSkin)
+    .abilId)
+
 // Used by bosses
 @compiletime function createBossHardenedSkin() returns AbilityDefinitionHardenedSkin
     return new AbilityDefinitionHardenedSkin(ABILITY_HARDENED_SKIN)
         ..setCheckDependencies(false)
-        ..setChancetoReduceDamage(1, 50.0)
+        ..setChancetoReduceDamage(1, CHANCE_TO_REDUCE * 100)
         ..setMinimumDamage(1, 1.0)
-        ..setIgnoredDamage(1, 17.0)
+        ..setIgnoredDamage(1, DMG_REDUCED)
         ..setEditorSuffix("(modded)")
 
 // Used by Disco Duck & The One
@@ -53,23 +75,38 @@ import LocalAssets
     return new AbilityDefinitionWeb(ABILITY_BOSS_ENSNARE)
         ..setIconNormal(Icons.bTNEnsnare)
         ..setBuffs(1, "Bena,Beng")
-        ..setButtonPositionNormalX(2)
-        ..setButtonPositionNormalY(1)
         ..setCheckDependencies(false)
         ..setCooldown(1, 10.0)
         ..setDurationNormal(1, 8.0)
         ..setEditorSuffix("(Boss Ensnare)")
         ..setDurationHero(1, 2.5)
-        ..setHotkeyNormal("R")
-        ..setMissileArt("Abilities\\Spells\\Orc\\Ensnare\\EnsnareMissile.mdl")
-        ..setRequirements("")
+        ..setMissileArt(Abilities.ensnaremissile)
         ..setCastRange(1, 700.0)
-        ..setTargetsAllowed(1, "air,enemies,ground,neutral,nonancient,organic")
+        ..presetTargetsAllowed(_ -> commaList(
+            TargetsAllowed.air,
+            TargetsAllowed.enemies,
+            TargetsAllowed.ground,
+            TargetsAllowed.neutral,
+            TargetsAllowed.nonancient,
+            TargetsAllowed.organic
+            )
+        )
         ..setTooltipNormal(1, "[|cffffd700R|r] Ensnare")
         ..setTooltipNormalExtended(1, "Binds an enemy target for 2.50/8 seconds on heroes/normal units.")
-        ..setIconTurnOff("ReplaceableTextures\\CommandButtons\\BTNEnsnare.blp")
-        ..setButtonPositionTurnOffX(2)
-        ..setButtonPositionTurnOffY(1)
-        ..setHotkeyTurnOff("R")
-        ..setTooltipTurnOff(1, "|cffc3dbffRight-click to activate auto-casting.|r")
-        ..setTooltipTurnOffExtended(1, "|cffc3dbffRight-click to deactivate auto-casting.|r")
+        ..setIconTurnOff(Icons.bTNEnsnare)
+
+let SPELL_RESISTANCE = 0.3
+
+public let ABILITY_SPELL_DMG_REDUCTION_DUMMY_BUFF = compiletime(createDummyBuffObject(
+    "Spell Damage Reduction".color(COLOR_GREEN),
+    "This unit has a thick skin; reduces spell damage by {0}"
+    .format(SPELL_RESISTANCE.toToolTipGreen()),
+    Icons.bTNThickFur)
+    .abilId)
+
+// Used by bosses
+@compiletime function createBossSpellResistance() returns AbilityDefinitionRunedBracers
+    return new AbilityDefinitionRunedBracers(ABILITY_SPELL_DMG_REDUCTION)
+        ..setDamageReduction(1, 0.3)
+        ..setName("Boss Spell Resistance")
+        ..setEditorSuffix("(modded)")

--- a/wurst/objects/units/Bosses/MidBossDefinition.wurst
+++ b/wurst/objects/units/Bosses/MidBossDefinition.wurst
@@ -9,11 +9,15 @@ import LinkedList
 import LocalObjectIDs
 import LocalAssets
 import ObjEditingUtils
+import BossAbilities
 
 let midBossAbilities = asList(
     AbilityIds.trueSight1,
     AbilityIds.resistantSkin,
-    ABILITY_HARDENED_SKIN
+    ABILITY_HARDENED_SKIN,
+    ABILITY_HARDENED_SKIN_DUMMY_BUFF,
+    ABILITY_SPELL_DMG_REDUCTION,
+    ABILITY_SPELL_DMG_REDUCTION_DUMMY_BUFF
 )
 
 // Add the given abilities to the standard list, rather than overwriting.

--- a/wurst/systems/entities/modules/Hostile.wurst
+++ b/wurst/systems/entities/modules/Hostile.wurst
@@ -15,6 +15,7 @@ import UnitEntity
 import PingMinimap
 import PlayerExtensions
 import ColorUtils
+import MagicResistance
 
 import initlater GreenFish
 import initlater Fish
@@ -36,6 +37,10 @@ public abstract class Hostile extends UnitEntity
 
     override function postCreate()
         super.postCreate()
+        if this instanceof Mammoth or this instanceof DiscoDuck
+            // 30% spell damage reduction
+            getUnit().setMagicResist(3)
+
 
     override function onDeath()
         if dropOnDeath

--- a/wurst/systems/entities/modules/Hostile.wurst
+++ b/wurst/systems/entities/modules/Hostile.wurst
@@ -15,7 +15,6 @@ import UnitEntity
 import PingMinimap
 import PlayerExtensions
 import ColorUtils
-import MagicResistance
 
 import initlater GreenFish
 import initlater Fish

--- a/wurst/systems/entities/modules/Hostile.wurst
+++ b/wurst/systems/entities/modules/Hostile.wurst
@@ -37,10 +37,6 @@ public abstract class Hostile extends UnitEntity
 
     override function postCreate()
         super.postCreate()
-        if this instanceof Mammoth or this instanceof DiscoDuck
-            // 30% spell damage reduction
-            getUnit().setMagicResist(3)
-
 
     override function onDeath()
         if dropOnDeath


### PR DESCRIPTION
$changelog: Added 30% Spell Resistance to Mammoth & Disco Duck.

This change has been requested for a while as it seems too easy for mage class to deal damage on mid-bosses.

I reused the MagicResistance.wurst code made by @HallerJohn to save time & to increase the codebase.

Should replace the "magic resistance" terminology by "spell resistance", magic implies that magic damage from bees are reduced, while it is not the case, only reduce damage from spells, it uses the runed brace item ability.