### PR TITLE
Prevented Shield Bash from targeting bosses.

### DIFF
--- a/wurst/objects/items/Armory/ShieldsDefinition.wurst
+++ b/wurst/objects/items/Armory/ShieldsDefinition.wurst
@@ -135,12 +135,18 @@ function getShield() returns LinkedList<Shield>
     ..setCooldown(1, COOLDOWN)
     ..setDurationHero(1, DURATION)
     ..setDurationNormal(1, DURATION)
-    ..setTargetsAllowed(1, "Ground,Neutral,Enemy,Organic")
+    ..presetTargetsAllowed(_ -> commaList(
+        TargetsAllowed.ground,
+        TargetsAllowed.neutral,
+        TargetsAllowed.enemies,
+        TargetsAllowed.organic,
+        TargetsAllowed.nonancient
+    ))
     ..setHeroAbility(false)
     ..setLevels(1)
     ..setItemAbility(true)
     ..setManaCost(1, 0)
-    ..setName("Steel Shield Bash")
+    ..setName("Shield Bash")
 
 @compiletime function buildShield()
     getShield().forEach(shield -> shield.buildShield())


### PR DESCRIPTION
$changelog: Prevented Shield Bash from targeting bosses.

Bashing boss would make them wander around, sometimes getting out of the mid-boss pit, preventing them from attacking for like 7-8 seconds, effectively saving a lot of meat for the attacker, that doesn't healthy at all, it's supposed to be a boss fight.

It sounds silly in the first place to be able to bash such huge monster with a shield.