### PR TITLE
Buffed scout lvl 1 & 2 reveal radius

### DIFF
--- a/wurst/objects/abilities/scout/Reveal.wurst
+++ b/wurst/objects/abilities/scout/Reveal.wurst
@@ -17,7 +17,7 @@ let DURATION = 8.
 let GREATER_DURATION = 10.
 let COOLDOWN = 20.
 let GREATER_COOLDOWN = 20.
-let AOE = 700.
+let AOE = 600.
 let GREATER_AOE = 2700.
 
 let CAST_TIME = 0.3
@@ -33,7 +33,7 @@ let TOOLTIP_EXTENDED_GREATER = "Reveals an large area around you, detects invisi
     new AbilityDefinitionFarseerFarSight(ABILITY_ID_REVEAL_DUMMY)
         ..setDummyAbility()
         ..setLevels(3)
-        ..presetAreaofEffect(lvl -> 300. + lvl * AOE)
+        ..presetAreaofEffect(lvl -> 600. + lvl * AOE)
         ..presetDurationHero(lvl -> DURATION)
         ..presetDurationNormal(lvl -> DURATION)
 


### PR DESCRIPTION
$changelog: Increased radius for Reveal slightly: for level 1 from 1000 to 1200, for level 2 from 1700 to 1800.

Scout level 1 reveal is deemed as useless as the radius is too low
Previous radius : 300 + 700, 300 + 700 * 2, 300 + 700 * 3

I increased starting radius and reduced radius per level to not affect level 3 radius as it is already pretty big
Current radius ; 600 + 600, 600 + 600 * 2, 600 + 600 * 3