### PR TITLE
Added global message indicating when a player chooses to be an observer.

### DIFF
--- a/wurst/systems/commands/Commands.wurst
+++ b/wurst/systems/commands/Commands.wurst
@@ -101,11 +101,7 @@ init
         )
 
     registerCommandAll("obs") (triggerPlayer, args) ->
-        printTimedToPlayer(
-            "You are now an observer.".color(GENERAL_COLOR),
-            10,
-            triggerPlayer
-        )
+        printTimed(triggerPlayer.getName() + " has became an observer", 10)
         triggerPlayer.makeObserver()
         if triggerPlayer == players[0]
             GameMode.endModeSelection(true)


### PR DESCRIPTION
$changelog: Added global message indicating when a player chooses to be an observer.

The red player currently has to check the allies tab to notice if a player has joined observer or not, adding this message would remove the hassle of having to periodically check the allies tab.