### PR TITLE
Changed text color for the map name to gold.

### DIFF
--- a/wurst.build
+++ b/wurst.build
@@ -4,7 +4,7 @@ dependencies:
 - https://github.com/crojewsk/wurstExtLibs
 - https://github.com/theQuazz/wurst-lodash
 buildMapData:
-  name: Island Troll Tribes v3.10b
+  name: '|cffffd700Island Troll Tribes v3.10b|r'
   fileName: Island.Troll.Tribes.v3.10b
   author: Quazz, Marsunpaisti, Xan Kriegor
   scenarioData:


### PR DESCRIPTION
It's easier to notice the lobby when the map name is colored in the lobby list, filtering the map name also brings up the downloaded map upward the list.
![21-09-18-19-28-25](https://user-images.githubusercontent.com/7768858/133903396-9a93c434-29b2-420e-8646-3f0a3fc3e58c.jpg)
