### PR TITLE
Removed mana burn visual effect from drain mana items

### DIFF
--- a/wurst/utils/ManaBurn.wurst
+++ b/wurst/utils/ManaBurn.wurst
@@ -21,13 +21,14 @@ function apply(unit caster, unit target, real damage, boolean burn)
     // Deal spell damage, if requested.
     if burn
         origin.damageTarget(target, actual, ATTACK_TYPE_NORMAL)
+        // Replicate the visual effects.
+        attachLightningFX(origin, target, LIGHTNING_MANA_BURN, 0.8)
+        flashEffect(Abilities.manaBurnTarget, target, AttachmentPoints.origin)
 
     // Update the mana.
     target.setMana(target.getMana() - actual)
 
-    // Replicate the visual effects.
-    attachLightningFX(origin, target, LIGHTNING_MANA_BURN, 0.8)
-    flashEffect(Abilities.manaBurnTarget, target, AttachmentPoints.origin)
+    // Display mana reduced
     createManaBurnTextTag(target, actual.floor())
         ..matchVisibility(target)
 


### PR DESCRIPTION
$changelog: Removed mana burn visual effect from dark spear & thistles

Dark spear & thistles apply a mana burn FX, this is confusing because mana burn FX implies spell damage from mana burn, those items only drain mana.