### PR TITLE
Fixed enable boat mode

### DIFF
--- a/wurst/systems/modes/GameConfig.wurst
+++ b/wurst/systems/modes/GameConfig.wurst
@@ -3,7 +3,6 @@ package GameConfig
 class GameConfig
     var numTribes = 2
     var playersPerTribe = 6
-    var enableTransportShips = true
     var heatPerCast = 15
     var hostileSpawnRate = 1.0
     var allTrollEnabled = false
@@ -47,7 +46,7 @@ class GameConfig
     var lavish = false
     var famine = false
 
-    var disabledBoats = false
+    var disabledBoats = true
     var petChance = 0.17
 
     var fishMax = 100


### PR DESCRIPTION
$changelog: Fixed bug where transport ship could be crafted without -enable-boat mode.