### PR TITLE
Fixed error in onCast listener.

### DIFF
--- a/wurst/objects/abilities/mage/elementalist/OverCharge.wurst
+++ b/wurst/objects/abilities/mage/elementalist/OverCharge.wurst
@@ -42,7 +42,7 @@ let TOOLTIP_EXTENDED = (
     DURATION.toToolTipLightBlue()
 )
 
-@compiletime function createOv()
+@compiletime function createOvercharge()
     new AbilityDefinitionAuraSlow(DUMMY_AURA_ID)
         ..setArtTarget(AURA_EFFECT_PATH)
         ..setTargetAttachmentPoint1("hand,right")


### PR DESCRIPTION
An error was raised upon [this line](https://github.com/wurstscript/WurstStdlib2/blob/62c6816ca91bbc507d4aad746b13d12fe7ab48c0/wurst/closures/ClosureEvents.wurst#L205). This change fixes the bug but it's still obscure as to why it happened in the first place. 

We theorize that the order in which the packages are initialized upon compile time may raise problems with some data structure, in this case, the hashMap used to register spell cast events was corrupted and the has method would return True when it should have returned False, causing the further execution to disfunction.