### PR TITLE
Fixed error when building map

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -108,7 +108,8 @@ def update_build(version):
     name = f"{name.rsplit(maxsplit=1)[0]} {version}"
 
     # Strip whitespace for the filename to ease access.
-    filename = ".".join(name.split())
+    # Remove color code if it exist in the name string
+    filename = ".".join((name[10:] if name[0] == "|" else name).split())
 
     # Update the build file.
     build["buildMapData"].update({


### PR DESCRIPTION
We added a color for the map name in #773, I didn't notice that the release script used the map name defined in the wurst build file to create a string for the filename, color code on filename crashes the wurst build script.