### PR TITLE
Fixed infinite loop caused by Barkskin reflecting.

### DIFF
--- a/wurst/objects/abilities/beastmaster/Druid/BarkSkin.wurst
+++ b/wurst/objects/abilities/beastmaster/Druid/BarkSkin.wurst
@@ -68,6 +68,9 @@ let BUFF_ID = compiletime(BUFF_ID_GEN.next())
 function onDamage()
     if not DamageEvent.getTarget().hasAbility(BUFF_ID)
         return
+    // Ignore damage coming from barkskin reflect
+    if DamageEvent.getId() == ABILITY_BARK_SKIN
+        return
     // Check if damage comes from basic attack
     if not DamageEvent.getType() == DamageType.ATTACK
         return
@@ -79,7 +82,7 @@ function onDamage()
 
     // ATTACK_TYPE_CHAOS to deal flat damage seems to be enough
     UnitDamageTarget(DamageEvent.getTarget(), DamageEvent.getSource(),
-    DamageEvent.getAmount() * THORNS_DMG, true, false, ATTACK_TYPE_CHAOS, DAMAGE_TYPE_NORMAL, null)
+    DamageEvent.getAmount() * THORNS_DMG, false, false, ATTACK_TYPE_CHAOS, null, null)
 
 
 init


### PR DESCRIPTION
$changelog: Fixed bug where two units with Barkskin fighting would cause the game to crash.

If 1 unit with barkskin buff attacks another unit with the same buff, reflected damage would trigger the buff damage in an infinite loop fashion.

Apparently just putting `ATTACK_TYPE_CHAOS` is enough to inflict pure damage.
