### PR TITLE
Added healing reduction buff to Cloak of healing

### DIFF
--- a/wurst/objects/abilities/HealingDebuff.wurst
+++ b/wurst/objects/abilities/HealingDebuff.wurst
@@ -1,0 +1,48 @@
+package HealingDebuff
+
+// Standard library imports:
+import BuffObjEditing
+import HashMap
+import TimerUtils
+import ClosureTimers
+
+// Local imports:
+import LocalAssets
+import HealingSystem
+import ColorUtils
+import ToolTipsUtils
+
+@configurable let debuffDuration = 30.
+@configurable let debuffFactor = 0.5
+
+public let DEBUFF_HEAL_TOOLTIP_SUFFIX = ("Heal Reduction\n".color(SPECIAL_COLOR) +
+    "Subsequent healing from Cloak and troll abilities are reduced by {0}, last {1} seconds.")
+    .format(debuffFactor.toToolTipRed(), debuffDuration.toToolTipLightBlue())
+let unitToTimer = new HashMap<unit, timer>
+
+let healDebuff = compiletime(createDummyBuffObject("Heal Reduction",
+    "Subsequent healing from abilities are reduced by 50%", LocalIcons.bTNCloakOfHealing))
+
+public function unit.addHealDebuff()
+    if not this.hasAbility(healDebuff.abilId)
+        this.addAbility(healDebuff.abilId)
+    startDebuffDuration(this)
+
+function startDebuffDuration(unit u)
+    // Remove the unit & release the timer if it exists
+    if unitToTimer.has(u)
+        unitToTimer.getAndRemove(u).release()
+
+    // Init new timer
+    let buffTimer = getTimer()
+    unitToTimer.put(u, buffTimer)
+    buffTimer.doAfter(debuffDuration) ->
+        unitToTimer.getAndRemove(u)
+        u.removeAbility(healDebuff.abilId)
+
+
+init
+    onUnitHealed() ->
+        let instance = getHealingInstance()
+        if instance.getTarget().hasAbility(healDebuff.buffId) and instance.healingType == HealingType.ABILITY
+            instance.scaleMultiplier(1 - debuffFactor)

--- a/wurst/objects/items/CloaksDefinition.wurst
+++ b/wurst/objects/items/CloaksDefinition.wurst
@@ -18,6 +18,7 @@ import Items
 import LocalItemObjEditing
 import HealingSystem
 import ColorUtils
+import HealingDebuff
 
 // Dummy abilities, I don't think they belong in LocalObjectsIDs
 let ABILITY_CLOAK_HEALING = compiletime(ABIL_ID_GEN.next())
@@ -75,6 +76,7 @@ public let CLOAK_FROST_TT   = COMMON_TT + ("can be cast to emit {0} ice waves, e
 
 public let CLOAK_HEALING_TT = COMMON_TT + "can be cast to restore all {0} health points to nearby allies over {1} seconds."
                               .format(HEALTH_RESTORED.toToolTipGreen(), RESTORE_DURATION.toToolTipLightBlue()) + makeToolTipCooldown(RESTORE_COOLDOWN)
+                              + "\nLast tick of healing applies " + "Heal Reduction".color(SPECIAL_COLOR) + ".\n\n" + DEBUFF_HEAL_TOOLTIP_SUFFIX
 public let CLOAK_MANA_TT    = COMMON_TT + "can be cast to restore {0} mana points to nearby allies over {1} seconds."
                               .format(CLOAK_MANA_RESTORED.toToolTipBlue(), RESTORE_DURATION.toToolTipLightBlue()) + makeToolTipCooldown(RESTORE_COOLDOWN)
 
@@ -234,6 +236,8 @@ function castRejuvHeal(unit caster, unit target, real duration, real amount)
         if not target.hasAbility(BUFF_HEAL)
             destroy cb
         new HealingInstance(target, caster, amount / duration, HealingType.ABILITY)
+        if cb.isLast()
+            target.addHealDebuff()
 
 function castRejuv(unit caster, int rejuvAbility)
     forUnitsInRange(caster.getPos(), RESTORE_RADIUS) (unit u) ->


### PR DESCRIPTION
$changelog: Healing Cloak last healing tick now applies Heal Reduction, subsequent healing from Cloak of healing and troll abilities are reduced by 50%

Problem: Healing Cloak is a cheap item and can be easily stacked, feedback from players mentions that stacking Healing Cloak feels kinda lame/make the game less interesting, added a diminished return on healing from Healing Cloak to reduce the efficiency of stacking.
![22-05-16-21-54-58](https://user-images.githubusercontent.com/7768858/168683656-ecd60351-2158-41be-88ab-204b791b82cb.jpg)
 