### PR TITLE
prevent healing cloak stacking + higher cd

### DIFF
--- a/wurst/objects/items/CloaksDefinition.wurst
+++ b/wurst/objects/items/CloaksDefinition.wurst
@@ -32,6 +32,8 @@ let FROST_RADIUS  = 500.
 let FLAMES_RADIUS = 300.
 
 let HEALTH_RESTORED = 150.
+let HEALTH_STACK_SCALE = 0.5
+
 let  CLOAK_MANA_RESTORED   = 100.
 
 let FROST_DMG = 5.
@@ -40,7 +42,8 @@ let FROST_AS_DEBUFF = 0.35
 
 let FLAMES_DMG = 7.
 
-let RESTORE_COOLDOWN = 35.
+let HEALTH_RESTORE_COOLDOWN = 50.
+let MANA_RESTORE_COOLDOWN = 35.
 let FROST_COOLDOWN = 35.
 
 let RESTORE_DURATION = 5.
@@ -73,10 +76,10 @@ public let CLOAK_FROST_TT   = COMMON_TT + ("can be cast to emit {0} ice waves, e
                                        FROST_TARGET_DURATION.toToolTipLightBlue()) +
                               makeToolTipCooldown(FROST_COOLDOWN)
 
-public let CLOAK_HEALING_TT = COMMON_TT + "can be cast to restore all {0} health points to nearby allies over {1} seconds."
-                              .format(HEALTH_RESTORED.toToolTipGreen(), RESTORE_DURATION.toToolTipLightBlue()) + makeToolTipCooldown(RESTORE_COOLDOWN)
+public let CLOAK_HEALING_TT = COMMON_TT + "can be cast to restore all {0} health points to nearby allies over {1} seconds. Concurrent healing by this ability is reduced by {2}."
+                              .format(HEALTH_RESTORED.toToolTipGreen(), RESTORE_DURATION.toToolTipLightBlue(), HEALTH_STACK_SCALE.toToolTipRed()) + makeToolTipCooldown(HEALTH_RESTORE_COOLDOWN)
 public let CLOAK_MANA_TT    = COMMON_TT + "can be cast to restore {0} mana points to nearby allies over {1} seconds."
-                              .format(CLOAK_MANA_RESTORED.toToolTipBlue(), RESTORE_DURATION.toToolTipLightBlue()) + makeToolTipCooldown(RESTORE_COOLDOWN)
+                              .format(CLOAK_MANA_RESTORED.toToolTipBlue(), RESTORE_DURATION.toToolTipLightBlue()) + makeToolTipCooldown(MANA_RESTORE_COOLDOWN)
 
 // Cloaks ItemDefinition
 function createCloak(int newId) returns ItemDefinition
@@ -134,11 +137,11 @@ function createCloak(int newId) returns ItemDefinition
 @compiletime function createCloakItemCast()
     createItemBerserkCast(ABILITY_CLOAK_HEALING)
         ..setName("Healing Cloak Cast")
-        ..setCooldown(1, RESTORE_COOLDOWN)
+        ..setCooldown(1, HEALTH_RESTORE_COOLDOWN)
 
     createItemBerserkCast(ABILITY_CLOAK_MANA)
         ..setName("Mana Cloak Cast")
-        ..setCooldown(1, RESTORE_COOLDOWN)
+        ..setCooldown(1, MANA_RESTORE_COOLDOWN)
 
     createItemBerserkCast(ABILITY_CLOAK_FROST)
         ..setName("Frost Cloak Cast")
@@ -243,9 +246,14 @@ function castRejuv(unit caster, int rejuvAbility)
             and not u.isHidden()
             and not u.isType(UNIT_TYPE_STRUCTURE)
 
+            var healAmount = HEALTH_RESTORED
+            if rejuvAbility == ABILITY_REJUV_HEALING
+                if u.hasAbility(BUFF_HEAL)
+                    healAmount = healAmount * HEALTH_STACK_SCALE
+
             InstantDummyCaster.castTarget(caster.getOwner(), rejuvAbility, 1, Orders.rejuvination, u)
             if rejuvAbility == ABILITY_REJUV_HEALING
-                castRejuvHeal(caster, u, RESTORE_DURATION, HEALTH_RESTORED)
+                castRejuvHeal(caster, u, RESTORE_DURATION, healAmount)
 
 function castAoESlowDebuff(unit caster)
     forUnitsInRange(caster.getPos(), FROST_RADIUS) (unit u) ->


### PR DESCRIPTION
$changelog: Healing cloak cooldown went from 35 to 50 seconds. Using two healing cloaks concurrently causes the second one to heal for 50% less.